### PR TITLE
Change to use associated types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,9 @@ mod services;
 pub use services::*;
 
 mod traits;
-pub use traits::{Identifier, IterableWireFormat, SingleValueWireFormat, WireFormat};
+pub use traits::{
+    DiagnosticDefinition, Identifier, IterableWireFormat, SingleValueWireFormat, WireFormat,
+};
 
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
@@ -33,34 +35,13 @@ use serde::{Deserialize, Serialize};
 pub const SUCCESS: u8 = 0x80;
 pub const PENDING: u8 = 0x78;
 
-/// A trait that defines the user-defined data specifiers for UDS requests and responses.
-///
-/// Used to specify the types of the identifiers and payloads used in UDS requests and responses.
-/// It allows for flexibility in defining custom data types while adhering to the UDS protocol.
-pub trait DataSpecifier {
-    /// UDS Data Identifier
-    ///
-    /// Requests : [ReadDataByIdentifierRequest], [WriteDataByIdentifierRequest], and [ReadDTCInfoRequest]
-    /// Responses: [ReadDataByIdentifierResponse], [WriteDataByIdentifierResponse], and [ReadDTCInfoResponse]
-    type DID: Identifier;
-    /// Response payload for [ReadDataByIdentifierRequest]
-    type DiagnosticPayload: IterableWireFormat;
-
-    /// UDS Routine Identifier
-    ///
-    /// This is used to identify the routine to be controlled in a [RoutineControlRequest]
-    type RID: Identifier;
-    /// Payload for both requests and responses of [RoutineControlRequest] and [RoutineControlResponse]
-    type RoutinePayload: WireFormat;
-}
-
-/// Basic UDS implementation of the [DataSpecifier] trait.
+/// Basic UDS implementation of the [DiagnosticDefinition] trait.
 ///
 /// This is an example of a simple data spec that can be used with UDS requests and responses.
 /// It should **not** be used directly in production code, but rather as a base for more complex data specifiers.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct UdsSpec;
-impl DataSpecifier for UdsSpec {
+impl DiagnosticDefinition for UdsSpec {
     type RID = ProtocolIdentifier;
     type DID = ProtocolIdentifier;
     type RoutinePayload = ProtocolPayload;

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,8 +6,8 @@ use crate::{
         RequestDownloadRequest, RoutineControlRequest, SecurityAccessRequest, TesterPresentRequest,
         TransferDataRequest, WriteDataByIdentifierRequest,
     },
-    DataSpecifier, Error, NegativeResponseCode, ReadDTCInfoRequest, ResetType, SecurityAccessType,
-    SingleValueWireFormat, WireFormat,
+    DiagnosticDefinition, Error, NegativeResponseCode, ReadDTCInfoRequest, ResetType,
+    SecurityAccessType, SingleValueWireFormat, WireFormat,
 };
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::io::{Read, Write};
@@ -22,7 +22,7 @@ use super::{
 /// Each variant corresponds to a request for a different UDS service
 /// The variants contain all request data for each service
 #[derive(Clone, Debug, PartialEq)]
-pub enum Request<D: DataSpecifier> {
+pub enum Request<D: DiagnosticDefinition> {
     ClearDiagnosticInfo(ClearDiagnosticInfoRequest),
     CommunicationControl(CommunicationControlRequest),
     ControlDTCSettings(ControlDTCSettingsRequest),
@@ -39,7 +39,7 @@ pub enum Request<D: DataSpecifier> {
     WriteDataByIdentifier(WriteDataByIdentifierRequest<D::DiagnosticPayload>),
 }
 
-impl<D: DataSpecifier> Request<D> {
+impl<D: DiagnosticDefinition> Request<D> {
     /// Create a `ClearDiagnosticInfo` request, clears diagnostic information in one or more servers' memory
     pub fn clear_diagnostic_info(group_of_dtc: DTCRecord, memory_selection: u8) -> Self {
         Request::ClearDiagnosticInfo(ClearDiagnosticInfoRequest::new(
@@ -241,7 +241,7 @@ impl<D: DataSpecifier> Request<D> {
     }
 }
 
-impl<T: DataSpecifier> WireFormat for Request<T> {
+impl<T: DiagnosticDefinition> WireFormat for Request<T> {
     /// Deserialization function to read a [`Request`] from a [`Reader`](std::io::Read)
     /// This function reads the service byte and then calls the appropriate
     /// deserialization function for the service in question
@@ -353,4 +353,4 @@ impl<T: DataSpecifier> WireFormat for Request<T> {
     }
 }
 
-impl<D: DataSpecifier> SingleValueWireFormat for Request<D> {}
+impl<D: DiagnosticDefinition> SingleValueWireFormat for Request<D> {}

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,6 @@
 use crate::{
     CommunicationControlResponse, CommunicationControlType, ControlDTCSettingsResponse,
-    DataSpecifier, DiagnosticSessionControlResponse, DiagnosticSessionType, DtcSettings,
+    DiagnosticDefinition, DiagnosticSessionControlResponse, DiagnosticSessionType, DtcSettings,
     EcuResetResponse, Error, NegativeResponse, NegativeResponseCode, ReadDTCInfoResponse,
     ReadDataByIdentifierResponse, RequestDownloadResponse, RequestFileTransferResponse, ResetType,
     RoutineControlResponse, SecurityAccessResponse, SecurityAccessType, SingleValueWireFormat,
@@ -16,7 +16,7 @@ pub struct UdsResponse {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Response<D: DataSpecifier> {
+pub enum Response<D: DiagnosticDefinition> {
     ClearDiagnosticInfo,
     /// Response to a [`CommunicationControlRequest`](crate::CommunicationControlRequest)
     CommunicationControl(CommunicationControlResponse),
@@ -43,7 +43,7 @@ pub enum Response<D: DataSpecifier> {
     WriteDataByIdentifier(WriteDataByIdentifierResponse<D::DID>),
 }
 
-impl<D: DataSpecifier> Response<D> {
+impl<D: DiagnosticDefinition> Response<D> {
     pub fn clear_diagnostic_info() -> Self {
         Response::ClearDiagnosticInfo
     }
@@ -135,7 +135,7 @@ impl<D: DataSpecifier> Response<D> {
     }
 }
 
-impl<D: DataSpecifier> WireFormat for Response<D> {
+impl<D: DiagnosticDefinition> WireFormat for Response<D> {
     fn option_from_reader<T: Read>(reader: &mut T) -> Result<Option<Self>, Error> {
         let service = UdsServiceType::response_from_byte(reader.read_u8()?);
         Ok(Some(match service {
@@ -243,4 +243,4 @@ impl<D: DataSpecifier> WireFormat for Response<D> {
     }
 }
 
-impl<D: DataSpecifier> SingleValueWireFormat for Response<D> {}
+impl<D: DiagnosticDefinition> SingleValueWireFormat for Response<D> {}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -141,6 +141,27 @@ where
     }
 }
 
+/// A trait that defines the user-defined diagnostic definitions/specifiers for UDS requests and responses.
+///
+/// Used to specify the types of the identifiers and payloads used in UDS requests and responses.
+/// It allows for flexibility in defining custom data types while adhering to the UDS protocol.
+pub trait DiagnosticDefinition {
+    /// UDS Data Identifier
+    ///
+    /// Requests : [ReadDataByIdentifierRequest], [WriteDataByIdentifierRequest], and [ReadDTCInfoRequest]
+    /// Responses: [ReadDataByIdentifierResponse], [WriteDataByIdentifierResponse], and [ReadDTCInfoResponse]
+    type DID: Identifier;
+    /// Response payload for [ReadDataByIdentifierRequest]
+    type DiagnosticPayload: IterableWireFormat;
+
+    /// UDS Routine Identifier
+    ///
+    /// This is used to identify the routine to be controlled in a [RoutineControlRequest]
+    type RID: Identifier;
+    /// Payload for both requests and responses of [RoutineControlRequest] and [RoutineControlResponse]
+    type RoutinePayload: WireFormat;
+}
+
 /// tests
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Instead of specifying the generics in the `Request` enum itself, move to an associated type to simplify the amount of code needed to be adjusted when adding a new payload or identifier.
* IE DTC IDs and Payloads will need to be added in the future, this will make that update a lot nicer to perform with way less lines changed 
 
https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-items.md