### PR TITLE
Routine Control Fix

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -36,7 +36,7 @@ pub enum Response<D: DiagnosticDefinition> {
     /// Response to a [`RequestTransferExit`](crate::RequestTransferExit)
     RequestTransferExit,
     /// Response to a [`RoutineControl` request](crate::RoutineControlRequest)
-    RoutineControl(RoutineControlResponse<D::RID, D::RoutinePayload>),
+    RoutineControl(RoutineControlResponse<D::RoutinePayload>),
     SecurityAccess(SecurityAccessResponse),
     TesterPresent(TesterPresentResponse),
     TransferData(TransferDataResponse),
@@ -91,14 +91,9 @@ impl<D: DiagnosticDefinition> Response<D> {
 
     pub fn routine_control(
         routine_control_type: crate::RoutineControlSubFunction,
-        routine_id: D::RID,
         data: D::RoutinePayload,
     ) -> Self {
-        Response::RoutineControl(RoutineControlResponse::new(
-            routine_control_type,
-            routine_id,
-            data,
-        ))
+        Response::RoutineControl(RoutineControlResponse::new(routine_control_type, data))
     }
 
     pub fn security_access(access_type: SecurityAccessType, security_seed: Vec<u8>) -> Self {


### PR DESCRIPTION
Let the routine control response payload read the identifier (like the DID payloads)

We were getting None returned if we read Response that ONLY sent the identifier and not any portion of a payload, because we were essentially reading the identifier twice. So remove the RID type from the response, and let the Payload read it instead