### PR TITLE
docs: Add description to Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "uds_protocol"
+description = "A library for encoding and decoding UDS (ISO 14229) messages"
 version = "0.0.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/uds_protocol_derive/Cargo.toml
+++ b/uds_protocol_derive/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "uds_protocol_derive"
+description = "Procedural macros for easier implementation of UDS protocol traits"
 version = "0.0.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Description is required in Cargo.toml before you can push to crates.io