### PR TITLE
feat: apply `Copy` and `ToSchema` common trait to all supported message types

### DIFF
--- a/src/common/dtc_ext_data.rs
+++ b/src/common/dtc_ext_data.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// The `DTCExtDataRecordNumber` is used in the request message to get a stored [`DTCExtDataRecord`]
 /// Its used to specify the type of `DTCExtDataRecord` to be reported.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, ToSchema)]
 pub enum DTCExtDataRecordNumber {
     // 0x00, 0xF0-0xFD are reserved
     ISOSAEReserved(u8),

--- a/src/common/dtc_status.rs
+++ b/src/common/dtc_status.rs
@@ -257,7 +257,7 @@ impl SingleValueWireFormat for DTCRecord {}
 /// For the purpose of:
 ///     * Requesting DTC status from a vehicle
 ///     * Clearing DTC information in the vehicle
-#[derive(Debug, Clone, Eq, Serialize, Deserialize, PartialEq, ToSchema)]
+#[derive(Debug, Clone, Copy, Eq, Serialize, Deserialize, PartialEq, ToSchema)]
 #[non_exhaustive]
 pub enum FunctionalGroupIdentifier {
     /// 0x00 to 0x32
@@ -429,7 +429,7 @@ impl From<u8> for DTCStoredDataRecordNumber {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 /// Represents a record containing information about the severity of a Diagnostic Trouble Code (DTC).
 pub struct DTCSeverityRecord {
     ///  The severity mask associated with the DTC, indicating the level of severity.

--- a/src/common/dtc_status.rs
+++ b/src/common/dtc_status.rs
@@ -429,7 +429,7 @@ impl From<u8> for DTCStoredDataRecordNumber {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, ToSchema)]
 /// Represents a record containing information about the severity of a Diagnostic Trouble Code (DTC).
 pub struct DTCSeverityRecord {
     ///  The severity mask associated with the DTC, indicating the level of severity.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub const PENDING: u8 = 0x78;
 ///
 /// This is an example of a simple data spec that can be used with UDS requests and responses.
 /// It should **not** be used directly in production code, but rather as a base for more complex data specifiers.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
 pub struct UdsSpec;
 impl DiagnosticDefinition for UdsSpec {
     type RID = UDSRoutineIdentifier;

--- a/src/services/clear_dtc_information.rs
+++ b/src/services/clear_dtc_information.rs
@@ -1,5 +1,6 @@
 use crate::{CLEAR_ALL_DTCS, DTCRecord, NegativeResponseCode, SingleValueWireFormat, WireFormat};
 use byteorder::{ReadBytesExt, WriteBytesExt};
+use clap::Parser;
 
 /// Negative response codes
 const CLEAR_DIAG_INFO_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] = [
@@ -9,7 +10,9 @@ const CLEAR_DIAG_INFO_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] = [
     NegativeResponseCode::GeneralProgrammingFailure,
 ];
 
-#[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+#[derive(
+    Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema, Parser,
+)]
 pub struct ClearDiagnosticInfoRequest {
     /// Can be either a DTC group (such as chassis/powertrain) or a single DTC
     pub group_of_dtc: DTCRecord,

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -15,7 +15,7 @@ type DTCFaultDetectionCounter = u8;
 /// Used to address the respective user-defined DTC memory when retrieving DTCs
 type MemorySelection = u8;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, ToSchema)]
 #[non_exhaustive]
 pub struct ReadDTCInfoRequest {
     pub dtc_subfunction: ReadDTCInfoSubFunction,
@@ -211,7 +211,7 @@ type DTCReadinessGroupIdentifier = u8; // RGID
 
 /// Subfunctions for the `ReadDTCInformation` service
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
 pub enum ReadDTCInfoSubFunction {
     /// * Parameter: `DTCStatusMask`
     ///

--- a/src/services/request_download.rs
+++ b/src/services/request_download.rs
@@ -23,7 +23,7 @@ const REQUEST_DOWNLOAD_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 6] = [
 ///
 /// This is a variable length Request, determined by the `address_and_length_format_identifier` value
 /// See ISO-14229-1:2020, Table H.1 for format information
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 #[non_exhaustive]
 pub struct RequestDownloadRequest {
     /// compression method (high nibble) and encrypting method (low nibble). 0x00 is no compression or encryption

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -536,7 +536,7 @@ impl WireFormat for DirSizePayload {
 /// [ReadDir]: FileOperationMode::ReadDir
 /// [ResumeFile]: FileOperationMode::ResumeFile
 /// [Response]: RequestFileTransferRequest (RequestFileTransferResponse)
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct PositionPayload {
     /// Specifies the byte position within the file at which the Tester will resume downloading after an initial download is suspended
     /// A download is suspended when the ECU stops receiving [`crate::TransferDataRequest`] requests and does not receive the

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -73,7 +73,7 @@ impl TryFrom<u8> for FileOperationMode {
 /// [ResumeFile]: FileOperationMode::ResumeFile
 /// [Request]: RequestFileTransferRequest (RequestFileTransferRequest)
 /// [Response]: RequestFileTransferResponse (RequestFileTransferResponse)
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 #[allow(clippy::struct_field_names)]
 pub struct SizePayload {
     /// Length in bytes for both `file_size_uncompressed` and `file_size_compressed`
@@ -168,7 +168,7 @@ impl SingleValueWireFormat for SizePayload {}
 /// [ReadDir]: FileOperationMode::ReadDir
 /// [ResumeFile]: FileOperationMode::ResumeFile
 /// [Request]: RequestFileTransferRequest (RequestFileTransferRequest)
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct NamePayload {
     /// 0x01 - 0x06, the type of operation to be applied to the file or directory specified in `file_path_and_name`
     ///
@@ -228,7 +228,7 @@ impl SingleValueWireFormat for NamePayload {}
 ///
 /// If this service is used to delete files or directories on the server,
 /// there is no need to use the `TransferData` or [`crate::UdsServiceType::RequestTransferExit`] services.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 #[non_exhaustive]
 pub enum RequestFileTransferRequest {
     /// Add a file to the server
@@ -346,7 +346,7 @@ impl WireFormat for RequestFileTransferRequest {
 /// [ReadDir]: FileOperationMode::ReadDir
 /// [ResumeFile]: FileOperationMode::ResumeFile
 /// [Response]: RequestFileTransferRequest (RequestFileTransferResponse)
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct SentDataPayload {
     /// Not related to `RequestDownload`
     length_format_identifier: u8,
@@ -406,7 +406,7 @@ impl WireFormat for SentDataPayload {
 /// [ReadDir]: FileOperationMode::ReadDir
 /// [ResumeFile]: FileOperationMode::ResumeFile
 /// [Response]: RequestFileTransferRequest (RequestFileTransferResponse)
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 #[allow(clippy::struct_field_names)]
 pub struct FileSizePayload {
     pub file_size_parameter_length: u16,
@@ -478,7 +478,7 @@ impl SingleValueWireFormat for FileSizePayload {}
 /// [ReadDir]: FileOperationMode::ReadDir
 /// [ResumeFile]: FileOperationMode::ResumeFile
 /// [Response]: RequestFileTransferRequest (RequestFileTransferResponse)
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct DirSizePayload {
     pub dir_info_parameter_length: u16,
     pub dir_info_length: u128,
@@ -536,7 +536,7 @@ impl WireFormat for DirSizePayload {
 /// [ReadDir]: FileOperationMode::ReadDir
 /// [ResumeFile]: FileOperationMode::ResumeFile
 /// [Response]: RequestFileTransferRequest (RequestFileTransferResponse)
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 pub struct PositionPayload {
     /// Specifies the byte position within the file at which the Tester will resume downloading after an initial download is suspended
     /// A download is suspended when the ECU stops receiving [`crate::TransferDataRequest`] requests and does not receive the


### PR DESCRIPTION
- Created a spreadsheet that tracks all the traits applied to the message types: [Link to spreadsheet](https://luminartech-my.sharepoint.com/:x:/r/personal/parth_patel_luminartech_com/Documents/Traits%20in%20uds_protocol.xlsx?d=w2804875775b6429fb985e2938679bf18&csf=1&web=1&e=7OYGDm)
- Proposed a set of common traits: [Proposed common traits: #15 ](https://github.com/luminartech/uds_protocol/issues/15#issuecomment-3309176318)
- Apply `Copy` and `ToSchema` trait to all valid message types.

Note:
- `Clap::Parser` should require a seperate ticket due to the amount of new code it would require to support the trait to allow generating message from terminal.

Closes: #15 
Closes: #16 