### PR TITLE
build(release): add cargo-release tooling + gated publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-release --version '^0.25' --locked
-      - run: cargo release publish --no-confirm --execute
+      # --allow-branch '*': a tag-push CI run is in detached-HEAD state, which
+      # cargo-release's branch check would otherwise reject. Publishing is
+      # already gated by the job `if:` above; this only relaxes the ref check.
+      - run: cargo release publish --allow-branch '*' --no-confirm --execute
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  semver-checks:
+    name: Semver Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: uds_protocol
+
+  publish:
+    name: Publish to crates.io
+    needs: semver-checks
+    if: github.event_name == 'push' && vars.UDS_PROTOCOL_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install cargo-release --version '^0.25' --locked
+      - run: cargo release publish --no-confirm --execute
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,5 @@ fuzz/artifacts/
 .omniscient/
 
 .DS_Store
+
+omniscient.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/uds_protocol"
 keywords = ["uds", "iso-14229", "automotive", "diagnostics", "obd"]
 categories = ["encoding", "embedded", "hardware-support"]
 authors = [
-    "Justin Kovacich<justin.kovacich@luminartech.com>",
-    "Kimberly Kryger <kim.kryger@luminartech.com>",
-    "Matthew Beisser <matthew.beisser@luminartech.com>",
-    "Parth Patel <parth.patel@luminartech.com>",
-    "Zachary Heylmun <zachary.heylmun@luminartech.com>",
+    "Justin Kovacich <justin_kovacich@microvision.com>",
+    "Kimberly Kryger <kim_kryger@microvision.com>",
+    "Matthew Beisser <matthew_beisser@microvision.com>",
+    "Parth Patel <parth_patel@microvision.com>",
+    "Zachary Heylmun <zachary_heylmun@microvision.com>",
 ]
 
 [features]

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,8 @@
+# cargo-release config for the standalone uds_protocol repo (single crate).
+publish = false
+registry = "crates-io"
+tag-name = "v{{version}}"
+tag-message = "uds_protocol v{{version}}"
+pre-release-commit-message = "chore(release): v{{version}}"
+allow-branch = ["main"]
+pre-release-hook = ["cargo", "test", "--locked"]


### PR DESCRIPTION
Phase A of DFT→Kellnr: add cargo-release config + a SemVer-gated publish workflow to uds_protocol (single-crate; tag `v{version}`, crates.io, `publish=false`). Also normalizes stale author emails to @microvision.com. No metadata churn — `repository` untouched.

Publish stays **deliberate**: the publish job only runs when `vars.UDS_PROTOCOL_PUBLISH_ENABLED` is set and the crates.io token is provisioned in CI. Nothing publishes on merge.

Part of the DFT→Kellnr Phase A program (per-repo release model).