### PR TITLE
API ergonomics & consistency pass (pre-tag)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,7 +328,8 @@ fuzz/corpus/
 fuzz/artifacts/
 
 .omniscient/
-
+omniscient.toml
 .DS_Store
+.superpowers/
 
 omniscient.toml

--- a/src/dtc/ext_data.rs
+++ b/src/dtc/ext_data.rs
@@ -49,7 +49,7 @@ impl DTCExtDataRecordNumber {
     /// Return the raw `u8` value of this record number.
     #[must_use]
     #[allow(clippy::match_same_arms)]
-    pub fn value(&self) -> u8 {
+    pub const fn value(&self) -> u8 {
         match self {
             Self::ISOSAEReserved(value) => *value,
             Self::VehicleManufacturer(value) => *value,

--- a/src/dtc/snapshot.rs
+++ b/src/dtc/snapshot.rs
@@ -32,7 +32,7 @@ impl DTCSnapshotRecordNumber {
     /// Return the raw `u8` value of this snapshot record number.
     #[must_use]
     #[allow(clippy::match_same_arms)]
-    pub fn value(&self) -> u8 {
+    pub const fn value(&self) -> u8 {
         match self {
             DTCSnapshotRecordNumber::Reserved(value) => *value,
             DTCSnapshotRecordNumber::Number(value) => *value,

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -299,7 +299,7 @@ pub enum FunctionalGroupIdentifier {
 impl FunctionalGroupIdentifier {
     /// Return the raw `u8` value of this functional group identifier.
     #[must_use]
-    pub fn value(&self) -> u8 {
+    pub const fn value(&self) -> u8 {
         match self {
             FunctionalGroupIdentifier::EmissionsSystemGroup => 0x33,
             FunctionalGroupIdentifier::SafetySystemGroup => 0xD0,

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -131,7 +131,7 @@ impl<'a> Decode<'a> for DTCStatusMask {
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum DTCFormatIdentifier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@ pub use service::UdsServiceType;
 
 mod services;
 pub use services::{
-    ClearDiagnosticInfoRequest, CommunicationControlRequest, CommunicationControlResponse,
+    ClearDiagnosticInfoRequest, ClearDiagnosticInfoResponse, CommunicationControlRequest,
+    CommunicationControlResponse,
     CommunicationControlType, CommunicationType, ControlDTCSettingsRequest,
     ControlDTCSettingsResponse, DiagnosticSessionControlRequest, DiagnosticSessionControlResponse,
     DiagnosticSessionType, DirSizePayload, DtcAndStatusIter, DtcFaultDetectionIter, DtcSettings,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub use services::{
     DtcSeverityAndStatusIter, EcuResetRequest, EcuResetResponse, FileOperationMode,
     FileSizePayload, NamePayload, NegativeResponse, PositionPayload, ReadDTCInfoRequest,
     ReadDTCInfoResponse, ReadDTCInfoSubFunction, ReadDataByIdentifierRequest,
+    ReadDataByIdentifierResponse,
     RequestDownloadRequest, RequestDownloadResponse, RequestFileTransferRequest,
     RequestFileTransferResponse, RequestTransferExitRequest, RequestTransferExitResponse,
     ResetType, RoutineControlRequest, RoutineControlResponse, RoutineControlSubFunction,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,20 +38,19 @@ pub use service::UdsServiceType;
 mod services;
 pub use services::{
     ClearDiagnosticInfoRequest, ClearDiagnosticInfoResponse, CommunicationControlRequest,
-    CommunicationControlResponse,
-    CommunicationControlType, CommunicationType, ControlDTCSettingsRequest,
-    ControlDTCSettingsResponse, DiagnosticSessionControlRequest, DiagnosticSessionControlResponse,
-    DiagnosticSessionType, DirSizePayload, DtcAndStatusIter, DtcFaultDetectionIter, DtcSettings,
-    DtcSeverityAndStatusIter, EcuResetRequest, EcuResetResponse, FileOperationMode,
-    FileSizePayload, NamePayload, NegativeResponse, PositionPayload, ReadDTCInfoRequest,
-    ReadDTCInfoResponse, ReadDTCInfoSubFunction, ReadDataByIdentifierRequest,
-    ReadDataByIdentifierResponse,
-    RequestDownloadRequest, RequestDownloadResponse, RequestFileTransferRequest,
-    RequestFileTransferResponse, RequestTransferExitRequest, RequestTransferExitResponse,
-    ResetType, RoutineControlRequest, RoutineControlResponse, RoutineControlSubFunction,
-    SecurityAccessLevel, SecurityAccessRequest, SecurityAccessResponse, SecurityAccessType,
-    SentDataPayload, SizePayload, TesterPresentRequest, TesterPresentResponse, TransferDataRequest,
-    TransferDataResponse, WriteDataByIdentifierRequest, WriteDataByIdentifierResponse,
+    CommunicationControlResponse, CommunicationControlType, CommunicationType,
+    ControlDTCSettingsRequest, ControlDTCSettingsResponse, DiagnosticSessionControlRequest,
+    DiagnosticSessionControlResponse, DiagnosticSessionType, DirSizePayload, DtcAndStatusIter,
+    DtcFaultDetectionIter, DtcSettings, DtcSeverityAndStatusIter, EcuResetRequest,
+    EcuResetResponse, FileOperationMode, FileSizePayload, NamePayload, NegativeResponse,
+    PositionPayload, ReadDTCInfoRequest, ReadDTCInfoResponse, ReadDTCInfoSubFunction,
+    ReadDataByIdentifierRequest, ReadDataByIdentifierResponse, RequestDownloadRequest,
+    RequestDownloadResponse, RequestFileTransferRequest, RequestFileTransferResponse,
+    RequestTransferExitRequest, RequestTransferExitResponse, ResetType, RoutineControlRequest,
+    RoutineControlResponse, RoutineControlSubFunction, SecurityAccessLevel, SecurityAccessRequest,
+    SecurityAccessResponse, SecurityAccessType, SentDataPayload, SizePayload, TesterPresentRequest,
+    TesterPresentResponse, TransferDataRequest, TransferDataResponse, WriteDataByIdentifierRequest,
+    WriteDataByIdentifierResponse,
 };
 
 #[cfg(test)]

--- a/src/response.rs
+++ b/src/response.rs
@@ -286,4 +286,17 @@ mod tests {
         let written = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(&buf[..written], &frame); // previously became 0x7F (NegativeResponse)
     }
+
+    #[test]
+    fn clear_diagnostic_info_response_rejects_trailing_bytes() {
+        // Bare SID round-trips; a conformant ClearDiagnosticInfo positive response is [0x54].
+        let (resp, rest) = Response::decode(&[0x54]).unwrap();
+        assert!(rest.is_empty());
+        assert!(matches!(resp, Response::ClearDiagnosticInfo(_)));
+        // Trailing bytes after the SID are now rejected (matches every other response arm).
+        assert!(matches!(
+            Response::decode(&[0x54, 0xAA]),
+            Err(crate::Error::IncorrectMessageLengthOrInvalidFormat)
+        ));
+    }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CommunicationControlResponse, ControlDTCSettingsResponse, Decode,
+    ClearDiagnosticInfoResponse, CommunicationControlResponse, ControlDTCSettingsResponse, Decode,
     DiagnosticSessionControlResponse, EcuResetResponse, Encode, Error, NegativeResponse,
     ReadDTCInfoResponse, RequestDownloadResponse, RequestFileTransferResponse,
     RequestTransferExitResponse, RoutineControlResponse, SecurityAccessResponse,
@@ -14,7 +14,7 @@ use crate::{
 #[non_exhaustive]
 pub enum Response<'a> {
     /// Positive response to `ClearDiagnosticInfo`.
-    ClearDiagnosticInfo,
+    ClearDiagnosticInfo(ClearDiagnosticInfoResponse),
     /// Positive response to `CommunicationControl`.
     CommunicationControl(CommunicationControlResponse),
     /// Positive response to `ControlDTCSettings`.
@@ -74,7 +74,9 @@ impl<'a> Decode<'a> for Response<'a> {
         let payload = &buf[1..];
 
         let response = match service {
-            UdsServiceType::ClearDiagnosticInfo => Self::ClearDiagnosticInfo,
+            UdsServiceType::ClearDiagnosticInfo => Self::ClearDiagnosticInfo(
+                <ClearDiagnosticInfoResponse as Decode>::decode_exact(payload)?,
+            ),
             UdsServiceType::CommunicationControl => Self::CommunicationControl(
                 <CommunicationControlResponse as Decode>::decode_exact(payload)?,
             ),
@@ -143,7 +145,7 @@ impl Response<'_> {
     /// Returns the response service-ID byte that frames this response on the wire.
     fn response_sid(&self) -> u8 {
         match self {
-            Self::ClearDiagnosticInfo => UdsServiceType::ClearDiagnosticInfo.response_to_byte(),
+            Self::ClearDiagnosticInfo(_) => UdsServiceType::ClearDiagnosticInfo.response_to_byte(),
             Self::CommunicationControl(_) => {
                 UdsServiceType::CommunicationControl.response_to_byte()
             }
@@ -175,7 +177,7 @@ impl Response<'_> {
 impl Encode for Response<'_> {
     fn encoded_size(&self) -> usize {
         let payload = match self {
-            Self::ClearDiagnosticInfo => 0,
+            Self::ClearDiagnosticInfo(resp) => resp.encoded_size(),
             Self::RequestTransferExit(resp) => resp.encoded_size(),
             Self::Other { data, .. } => data.len(),
             Self::CommunicationControl(resp) => resp.encoded_size(),
@@ -201,7 +203,7 @@ impl Encode for Response<'_> {
             .write_all(&[self.response_sid()])
             .map_err(Error::io)?;
         let payload = match self {
-            Self::ClearDiagnosticInfo => 0,
+            Self::ClearDiagnosticInfo(resp) => resp.encode(writer)?,
             Self::RequestTransferExit(resp) => resp.encode(writer)?,
             Self::CommunicationControl(resp) => resp.encode(writer)?,
             Self::ControlDTCSettings(resp) => resp.encode(writer)?,

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,9 +1,10 @@
 use crate::{
     ClearDiagnosticInfoResponse, CommunicationControlResponse, ControlDTCSettingsResponse, Decode,
     DiagnosticSessionControlResponse, EcuResetResponse, Encode, Error, NegativeResponse,
-    ReadDTCInfoResponse, RequestDownloadResponse, RequestFileTransferResponse,
-    RequestTransferExitResponse, RoutineControlResponse, SecurityAccessResponse,
-    TesterPresentResponse, TransferDataResponse, UdsServiceType, WriteDataByIdentifierResponse,
+    ReadDTCInfoResponse, ReadDataByIdentifierResponse, RequestDownloadResponse,
+    RequestFileTransferResponse, RequestTransferExitResponse, RoutineControlResponse,
+    SecurityAccessResponse, TesterPresentResponse, TransferDataResponse, UdsServiceType,
+    WriteDataByIdentifierResponse,
 };
 
 /// Parsed zero-copy UDS response. Borrows from the wire buffer.
@@ -34,7 +35,7 @@ pub enum Response<'a> {
     /// cannot split it into `(DID, value)` pairs. Parse it caller-side once you know each
     /// DID's record length — read the 2-byte big-endian DID, take the application-defined
     /// number of data bytes, then repeat on the remainder.
-    ReadDataByIdentifier(&'a [u8]),
+    ReadDataByIdentifier(ReadDataByIdentifierResponse<'a>),
     /// Positive response to `ReadDTCInformation` with lazy iterators.
     ReadDTCInfo(ReadDTCInfoResponse<'a>),
     /// Positive response to `RequestDownload`.
@@ -92,7 +93,9 @@ impl<'a> Decode<'a> for Response<'a> {
             UdsServiceType::NegativeResponse => {
                 Self::NegativeResponse(<NegativeResponse as Decode>::decode_exact(payload)?)
             }
-            UdsServiceType::ReadDataByIdentifier => Self::ReadDataByIdentifier(payload),
+            UdsServiceType::ReadDataByIdentifier => {
+                Self::ReadDataByIdentifier(ReadDataByIdentifierResponse::new(payload))
+            }
             UdsServiceType::ReadDTCInfo => {
                 Self::ReadDTCInfo(<ReadDTCInfoResponse as Decode>::decode_exact(payload)?)
             }
@@ -185,7 +188,7 @@ impl Encode for Response<'_> {
             Self::DiagnosticSessionControl(resp) => resp.encoded_size(),
             Self::EcuReset(resp) => resp.encoded_size(),
             Self::NegativeResponse(resp) => resp.encoded_size(),
-            Self::ReadDataByIdentifier(bytes) => bytes.len(),
+            Self::ReadDataByIdentifier(resp) => resp.encoded_size(),
             Self::WriteDataByIdentifier(resp) => resp.encoded_size(),
             Self::ReadDTCInfo(resp) => resp.encoded_size(),
             Self::RequestDownload(resp) => resp.encoded_size(),
@@ -210,10 +213,7 @@ impl Encode for Response<'_> {
             Self::DiagnosticSessionControl(resp) => resp.encode(writer)?,
             Self::EcuReset(resp) => resp.encode(writer)?,
             Self::NegativeResponse(resp) => resp.encode(writer)?,
-            Self::ReadDataByIdentifier(bytes) => {
-                writer.write_all(bytes).map_err(Error::io)?;
-                bytes.len()
-            }
+            Self::ReadDataByIdentifier(resp) => resp.encode(writer)?,
             Self::WriteDataByIdentifier(resp) => resp.encode(writer)?,
             Self::ReadDTCInfo(resp) => resp.encode(writer)?,
             Self::RequestDownload(resp) => resp.encode(writer)?,

--- a/src/response.rs
+++ b/src/response.rs
@@ -290,8 +290,8 @@ mod tests {
     #[test]
     fn clear_diagnostic_info_response_rejects_trailing_bytes() {
         // Bare SID round-trips; a conformant ClearDiagnosticInfo positive response is [0x54].
-        let (resp, rest) = Response::decode(&[0x54]).unwrap();
-        assert!(rest.is_empty());
+        let (resp, remaining) = Response::decode(&[0x54]).unwrap();
+        assert!(remaining.is_empty());
         assert!(matches!(resp, Response::ClearDiagnosticInfo(_)));
         // Trailing bytes after the SID are now rejected (matches every other response arm).
         assert!(matches!(

--- a/src/services/clear_dtc_information.rs
+++ b/src/services/clear_dtc_information.rs
@@ -26,6 +26,8 @@ impl Encode for ClearDiagnosticInfoResponse {
 }
 
 impl<'a> Decode<'a> for ClearDiagnosticInfoResponse {
+    /// Consumes zero bytes and returns the full buffer as the remainder.
+    /// `decode_exact` at the call site (in `Response::decode`) enforces that no trailing bytes follow the SID.
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), crate::Error> {
         Ok((Self, buf))
     }

--- a/src/services/clear_dtc_information.rs
+++ b/src/services/clear_dtc_information.rs
@@ -1,6 +1,36 @@
 //! `ClearDiagnosticInformation` (0x14) service implementation
 use crate::{CLEAR_ALL_DTCS, DTCRecord, Decode, Encode, NegativeResponseCode};
 
+/// Positive response to `ClearDiagnosticInformation`. Carries no payload.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct ClearDiagnosticInfoResponse;
+
+impl ClearDiagnosticInfoResponse {
+    /// Create a `ClearDiagnosticInfoResponse`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Encode for ClearDiagnosticInfoResponse {
+    fn encoded_size(&self) -> usize {
+        0
+    }
+    fn encode(&self, _writer: &mut impl embedded_io::Write) -> Result<usize, crate::Error> {
+        Ok(0)
+    }
+}
+
+impl<'a> Decode<'a> for ClearDiagnosticInfoResponse {
+    fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), crate::Error> {
+        Ok((Self, buf))
+    }
+}
+
 /// Negative response codes
 const CLEAR_DIAG_INFO_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] = [
     NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
@@ -106,5 +136,22 @@ mod request {
         let all = ClearDiagnosticInfoRequest::clear_all(0);
         let compare = ClearDiagnosticInfoRequest::new(CLEAR_ALL_DTCS, 0);
         assert_eq!(all, compare);
+    }
+}
+
+#[cfg(test)]
+mod response {
+    use super::*;
+    use crate::{Decode, Encode};
+
+    #[test]
+    fn clear_dtc_response_roundtrips_empty() {
+        let resp = ClearDiagnosticInfoResponse::new();
+        let mut buf = [0u8; 4];
+        let n = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();
+        assert_eq!(n, 0);
+        let (decoded, rest) = <ClearDiagnosticInfoResponse as Decode>::decode(&buf[..0]).unwrap();
+        assert_eq!(decoded, resp);
+        assert!(rest.is_empty());
     }
 }

--- a/src/services/clear_dtc_information.rs
+++ b/src/services/clear_dtc_information.rs
@@ -152,8 +152,9 @@ mod response {
         let mut buf = [0u8; 4];
         let n = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(n, 0);
-        let (decoded, rest) = <ClearDiagnosticInfoResponse as Decode>::decode(&buf[..0]).unwrap();
+        let (decoded, remaining) =
+            <ClearDiagnosticInfoResponse as Decode>::decode(&buf[..0]).unwrap();
         assert_eq!(decoded, resp);
-        assert!(rest.is_empty());
+        assert!(remaining.is_empty());
     }
 }

--- a/src/services/control_dtc_settings.rs
+++ b/src/services/control_dtc_settings.rs
@@ -1,6 +1,6 @@
 //! `ControlDTCSetting` (0x85) service implementation
 use crate::shared::SuppressablePositiveResponse;
-use crate::{Decode, Encode, Error};
+use crate::{Decode, Encode, Error, NegativeResponseCode};
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -49,6 +49,13 @@ pub struct ControlDTCSettingsRequest {
     pub setting: DtcSettings,
 }
 
+const CONTROL_DTC_SETTINGS_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] = [
+    NegativeResponseCode::SubFunctionNotSupported,
+    NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
+    NegativeResponseCode::ConditionsNotCorrect,
+    NegativeResponseCode::RequestOutOfRange,
+];
+
 impl ControlDTCSettingsRequest {
     /// Create a new `ControlDTCSettingsRequest`.
     #[must_use]
@@ -57,6 +64,12 @@ impl ControlDTCSettingsRequest {
             suppress_positive_response,
             setting,
         }
+    }
+
+    /// Get the allowed [`NegativeResponseCode`] variants for this request.
+    #[must_use]
+    pub fn allowed_nack_codes() -> &'static [NegativeResponseCode] {
+        &CONTROL_DTC_SETTINGS_NEGATIVE_RESPONSE_CODES
     }
 }
 
@@ -137,7 +150,7 @@ impl<'a> Decode<'a> for ControlDTCSettingsResponse {
 #[cfg(test)]
 mod request {
     use super::*;
-    use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
+    use crate::{Decode, Encode, NegativeResponseCode, test_util::assert_encode_size_agrees};
     #[cfg(feature = "alloc")]
     use alloc::{vec, vec::Vec};
 
@@ -163,6 +176,13 @@ mod request {
         // service's Invalid<Service>Type error, not the generic length/format error.
         let err = <ControlDTCSettingsRequest as Decode>::decode(&[0x09]).unwrap_err();
         assert!(matches!(err, Error::InvalidDtcSetting(0x09)));
+    }
+
+    #[test]
+    fn exposes_allowed_nack_codes() {
+        assert!(!ControlDTCSettingsRequest::allowed_nack_codes().is_empty());
+        assert!(ControlDTCSettingsRequest::allowed_nack_codes()
+            .contains(&NegativeResponseCode::RequestOutOfRange));
     }
 }
 

--- a/src/services/control_dtc_settings.rs
+++ b/src/services/control_dtc_settings.rs
@@ -96,7 +96,7 @@ impl<'a> Decode<'a> for ControlDTCSettingsRequest {
 /// The ECU will respond with a `ControlDTCSettingsResponse` if the request was successful.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct ControlDTCSettingsResponse {
     /// The DTC logging setting that was set in the request
@@ -186,5 +186,10 @@ mod response {
         let (parsed, _) = <ControlDTCSettingsResponse as Decode>::decode(&buffer).unwrap();
         assert_eq!(parsed.setting, DtcSettings::On);
         assert_encode_size_agrees(&req);
+    }
+
+    #[test]
+    fn response_is_eq() {
+        crate::test_util::assert_impl_eq::<ControlDTCSettingsResponse>();
     }
 }

--- a/src/services/control_dtc_settings.rs
+++ b/src/services/control_dtc_settings.rs
@@ -181,8 +181,10 @@ mod request {
     #[test]
     fn exposes_allowed_nack_codes() {
         assert!(!ControlDTCSettingsRequest::allowed_nack_codes().is_empty());
-        assert!(ControlDTCSettingsRequest::allowed_nack_codes()
-            .contains(&NegativeResponseCode::RequestOutOfRange));
+        assert!(
+            ControlDTCSettingsRequest::allowed_nack_codes()
+                .contains(&NegativeResponseCode::RequestOutOfRange)
+        );
     }
 }
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,5 +1,5 @@
 mod clear_dtc_information;
-pub use clear_dtc_information::ClearDiagnosticInfoRequest;
+pub use clear_dtc_information::{ClearDiagnosticInfoRequest, ClearDiagnosticInfoResponse};
 
 mod communication_control;
 pub use communication_control::{

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -24,7 +24,7 @@ mod negative_response;
 pub use negative_response::NegativeResponse;
 
 mod read_data_by_identifier;
-pub use read_data_by_identifier::ReadDataByIdentifierRequest;
+pub use read_data_by_identifier::{ReadDataByIdentifierRequest, ReadDataByIdentifierResponse};
 
 mod read_dtc_information;
 pub use read_dtc_information::{

--- a/src/services/read_data_by_identifier.rs
+++ b/src/services/read_data_by_identifier.rs
@@ -11,7 +11,18 @@ const READ_DID_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 5] = [
 
 /// Read-DID request: a list of 16-bit Data Identifiers. Built from native `&[u16]`
 /// or borrowed from the wire as big-endian bytes; `dids()` yields `u16` either way.
+///
+/// # serde / utoipa carve-out
+///
+/// serde derives are omitted: the zero-copy `Native(&[u16])` backing has no borrowed
+/// `Deserialize` impl in serde (zero-copy borrowing via `#[serde(borrow)]` only works
+/// for `&[u8]` and `&str`, not `&[u16]`). This matches the `ReadDTCInfoResponse`
+/// best-effort-serde precedent in the design.
+///
+/// utoipa derives are omitted: `utoipa::ToSchema` cannot be derived on
+/// `ReadDataByIdentifierRequest` without also deriving it on the private `Dids` enum.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct ReadDataByIdentifierRequest<'d> {
     dids: Dids<'d>,
 }
@@ -108,7 +119,13 @@ impl<'a> Decode<'a> for ReadDataByIdentifierRequest<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_util::assert_encode_size_agrees;
+    use crate::test_util::{assert_encode_size_agrees, assert_impl_eq};
+
+    #[test]
+    fn derive_contract() {
+        assert_impl_eq::<ReadDataByIdentifierRequest<'static>>();
+        // serde: omitted — see struct-level doc comment for rationale
+    }
 
     #[test]
     fn rdbi_native_encodes_be() {

--- a/src/services/read_data_by_identifier.rs
+++ b/src/services/read_data_by_identifier.rs
@@ -1,6 +1,52 @@
 //! `ReadDataByIdentifier` (0x22) service implementation
 use crate::{Decode, Encode, Error, NegativeResponseCode};
 
+/// Positive response to `ReadDataByIdentifier`: raw `[DID][data record]…` bytes.
+///
+/// Left opaque **by design**: each data record's length is defined by the ECU's
+/// configuration for that DID and is not present on the wire, so the library cannot
+/// split it into `(DID, value)` pairs. Read the 2-byte big-endian DID, take the
+/// application-defined number of data bytes via [`records`](Self::records), then repeat.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct ReadDataByIdentifierResponse<'a> {
+    #[cfg_attr(feature = "serde", serde(borrow))]
+    records: &'a [u8],
+}
+
+impl<'a> ReadDataByIdentifierResponse<'a> {
+    /// Wrap the raw record bytes of a positive `ReadDataByIdentifier` response.
+    #[must_use]
+    pub const fn new(records: &'a [u8]) -> Self {
+        Self { records }
+    }
+
+    /// The raw `[DID][data record]…` bytes, to be parsed caller-side.
+    #[must_use]
+    pub const fn records(&self) -> &'a [u8] {
+        self.records
+    }
+}
+
+impl Encode for ReadDataByIdentifierResponse<'_> {
+    fn encoded_size(&self) -> usize {
+        self.records.len()
+    }
+
+    fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
+        writer.write_all(self.records).map_err(Error::io)?;
+        Ok(self.records.len())
+    }
+}
+
+impl<'a> Decode<'a> for ReadDataByIdentifierResponse<'a> {
+    fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
+        Ok((Self { records: buf }, &[]))
+    }
+}
+
 const READ_DID_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 5] = [
     NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
     NegativeResponseCode::ResponseTooLong,
@@ -165,6 +211,18 @@ mod test {
         assert!(<ReadDataByIdentifierRequest as Decode>::decode(&[]).is_err());
         assert!(<ReadDataByIdentifierRequest as Decode>::decode(&[0xF1]).is_err());
         assert!(<ReadDataByIdentifierRequest as Decode>::decode(&[0xF1, 0x90, 0xF1]).is_err());
+    }
+
+    #[test]
+    fn rdbi_response_wraps_and_roundtrips() {
+        use crate::{Decode, Encode};
+        let raw = [0xF1, 0x90, 0x01, 0x02];
+        let (resp, rest) = <ReadDataByIdentifierResponse as Decode>::decode(&raw).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(resp.records(), &raw);
+        let mut buf = [0u8; 8];
+        let n = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();
+        assert_eq!(&buf[..n], &raw);
     }
 
     #[test]

--- a/src/services/read_data_by_identifier.rs
+++ b/src/services/read_data_by_identifier.rs
@@ -217,8 +217,8 @@ mod test {
     fn rdbi_response_wraps_and_roundtrips() {
         use crate::{Decode, Encode};
         let raw = [0xF1, 0x90, 0x01, 0x02];
-        let (resp, rest) = <ReadDataByIdentifierResponse as Decode>::decode(&raw).unwrap();
-        assert!(rest.is_empty());
+        let (resp, remaining) = <ReadDataByIdentifierResponse as Decode>::decode(&raw).unwrap();
+        assert!(remaining.is_empty());
         assert_eq!(resp.records(), &raw);
         let mut buf = [0u8; 8];
         let n = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();

--- a/src/services/read_data_by_identifier.rs
+++ b/src/services/read_data_by_identifier.rs
@@ -62,8 +62,8 @@ const READ_DID_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 5] = [
 ///
 /// serde derives are omitted: the zero-copy `Native(&[u16])` backing has no borrowed
 /// `Deserialize` impl in serde (zero-copy borrowing via `#[serde(borrow)]` only works
-/// for `&[u8]` and `&str`, not `&[u16]`). This matches the `ReadDTCInfoResponse`
-/// best-effort-serde precedent in the design.
+/// for `&[u8]` and `&str`, not `&[u16]`), so `Dids::Native(&[u16])` cannot be
+/// deserialized without an owned allocation.
 ///
 /// utoipa derives are omitted: `utoipa::ToSchema` cannot be derived on
 /// `ReadDataByIdentifierRequest` without also deriving it on the private `Dids` enum.

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -14,7 +14,7 @@ type MemorySelection = u8;
 /// Request for the server to report diagnostic trouble code information
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct ReadDTCInfoRequest {
     /// The sub-function specifying what DTC information to report.
@@ -24,7 +24,7 @@ pub struct ReadDTCInfoRequest {
 impl ReadDTCInfoRequest {
     /// Create a new `ReadDTCInfoRequest`.
     #[must_use]
-    pub fn new(dtc_subfunction: ReadDTCInfoSubFunction) -> Self {
+    pub const fn new(dtc_subfunction: ReadDTCInfoSubFunction) -> Self {
         Self { dtc_subfunction }
     }
 }
@@ -229,7 +229,7 @@ mod read_dtc_info_request_encode_tests {
 /// A DTC paired with its fault detection counter value
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DTCFaultDetectionCounterRecord {
     pub dtc_record: DTCRecord,
     pub dtc_fault_detection_counter: DTCFaultDetectionCounter,
@@ -693,7 +693,9 @@ impl Iterator for DtcSeverityAndStatusIter<'_> {
 /// `ReadDTCInformation` defines further sub-functions that are **not yet modeled**;
 /// [`decode`](Self::decode) returns [`Error::InvalidDtcSubfunctionType`] for those. See the
 /// support table in the crate README. This is the "Partial" coverage noted there, not a bug.
-#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ReadDTCInfoResponse<'a> {
     /// Sub-functions 0x01, 0x07: count of DTCs matching a mask.
@@ -712,11 +714,13 @@ pub enum ReadDTCInfoResponse<'a> {
         /// DTC status availability mask.
         status_availability_mask: DTCStatusAvailabilityMask,
         /// Raw record bytes — use [`DtcAndStatusIter`] to iterate.
+        #[cfg_attr(feature = "serde", serde(borrow))]
         raw_records: &'a [u8],
     },
     /// Sub-function 0x14: list of DTC fault detection counter records.
     DTCFaultDetectionCounterList {
         /// Raw record bytes — use [`DtcFaultDetectionIter`] to iterate.
+        #[cfg_attr(feature = "serde", serde(borrow))]
         raw_records: &'a [u8],
     },
     /// Sub-functions 0x08, 0x09: list of DTC severity records.
@@ -729,6 +733,7 @@ pub enum ReadDTCInfoResponse<'a> {
         /// 3-byte DTC + status). These differ from the 5-byte WWH-OBD records, so
         /// [`DtcSeverityAndStatusIter`] does **not** apply here; no severity-list iterator is
         /// wired yet, so parse these bytes caller-side until one is added.
+        #[cfg_attr(feature = "serde", serde(borrow))]
         raw_records: &'a [u8],
     },
     /// Sub-function 0x42: WWH-OBD DTC by mask with severity info.
@@ -742,6 +747,7 @@ pub enum ReadDTCInfoResponse<'a> {
         /// DTC format identifier.
         format_identifier: DTCFormatIdentifier,
         /// Raw record bytes (5 bytes per record) — use [`DtcSeverityAndStatusIter`].
+        #[cfg_attr(feature = "serde", serde(borrow))]
         raw_records: &'a [u8],
     },
 }
@@ -925,6 +931,31 @@ impl Encode for ReadDTCInfoResponse<'_> {
             }
         }
         Ok(self.encoded_size())
+    }
+}
+
+#[cfg(test)]
+mod derive_contract {
+    use super::*;
+    use crate::test_util::assert_impl_eq;
+    #[cfg(feature = "serde")]
+    use crate::test_util::assert_impl_serde;
+
+    const _: ReadDTCInfoRequest = ReadDTCInfoRequest::new(
+        ReadDTCInfoSubFunction::ReportDTC_ByStatusMask(DTCStatusMask::TestFailed),
+    );
+
+    #[test]
+    fn eq_impls() {
+        assert_impl_eq::<ReadDTCInfoRequest>();
+        assert_impl_eq::<DTCFaultDetectionCounterRecord>();
+        assert_impl_eq::<ReadDTCInfoResponse<'static>>();
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_impls() {
+        assert_impl_serde::<ReadDTCInfoResponse<'static>>();
     }
 }
 

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -240,8 +240,10 @@ mod read_dtc_info_request_encode_tests {
     #[test]
     fn exposes_allowed_nack_codes() {
         assert!(!ReadDTCInfoRequest::allowed_nack_codes().is_empty());
-        assert!(ReadDTCInfoRequest::allowed_nack_codes()
-            .contains(&NegativeResponseCode::RequestOutOfRange));
+        assert!(
+            ReadDTCInfoRequest::allowed_nack_codes()
+                .contains(&NegativeResponseCode::RequestOutOfRange)
+        );
     }
 }
 

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -3,13 +3,19 @@
 use crate::{
     DTCExtDataRecordNumber, DTCFormatIdentifier, DTCRecord, DTCSeverityMask,
     DTCSnapshotRecordNumber, DTCStatusMask, DTCStoredDataRecordNumber, Decode, Encode, Error,
-    FunctionalGroupIdentifier,
+    FunctionalGroupIdentifier, NegativeResponseCode,
 };
 
 /// Used for non-emissions related servers
 type DTCFaultDetectionCounter = u8;
 /// Used to address the respective user-defined DTC memory when retrieving DTCs
 type MemorySelection = u8;
+
+const READ_DTC_INFO_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 3] = [
+    NegativeResponseCode::SubFunctionNotSupported,
+    NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
+    NegativeResponseCode::RequestOutOfRange,
+];
 
 /// Request for the server to report diagnostic trouble code information
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -26,6 +32,12 @@ impl ReadDTCInfoRequest {
     #[must_use]
     pub const fn new(dtc_subfunction: ReadDTCInfoSubFunction) -> Self {
         Self { dtc_subfunction }
+    }
+
+    /// Get the allowed [`NegativeResponseCode`] variants for this request.
+    #[must_use]
+    pub fn allowed_nack_codes() -> &'static [NegativeResponseCode] {
+        &READ_DTC_INFO_NEGATIVE_RESPONSE_CODES
     }
 }
 
@@ -150,7 +162,7 @@ impl<'a> Decode<'a> for ReadDTCInfoRequest {
 #[cfg(test)]
 mod read_dtc_info_request_encode_tests {
     use super::*;
-    use crate::test_util::assert_encode_size_agrees;
+    use crate::{NegativeResponseCode, test_util::assert_encode_size_agrees};
 
     #[test]
     fn encode_no_param_subfunction() {
@@ -223,6 +235,13 @@ mod read_dtc_info_request_encode_tests {
             let decoded = <ReadDTCInfoRequest as Decode>::decode_exact(&buf[..written]).unwrap();
             assert_eq!(decoded, req);
         }
+    }
+
+    #[test]
+    fn exposes_allowed_nack_codes() {
+        assert!(!ReadDTCInfoRequest::allowed_nack_codes().is_empty());
+        assert!(ReadDTCInfoRequest::allowed_nack_codes()
+            .contains(&NegativeResponseCode::RequestOutOfRange));
     }
 }
 

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -383,7 +383,7 @@ pub enum ReadDTCInfoSubFunction {
 impl ReadDTCInfoSubFunction {
     /// Return the raw `u8` sub-function byte.
     #[must_use]
-    pub fn value(&self) -> u8 {
+    pub const fn value(&self) -> u8 {
         match self {
             Self::ReportNumberOfDTC_ByStatusMask(_) => 0x01,
             Self::ReportDTC_ByStatusMask(_) => 0x02,

--- a/src/services/request_download.rs
+++ b/src/services/request_download.rs
@@ -24,7 +24,7 @@ const REQUEST_DOWNLOAD_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 6] = [
 /// See ISO-14229-1:2020, Table H.1 for format information
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct RequestDownloadRequest {
     /// compression method (high nibble) and encrypting method (low nibble). 0x00 is no compression or encryption
@@ -147,12 +147,16 @@ impl<'a> Decode<'a> for RequestDownloadRequest {
 /// Zero-alloc response for request download. Borrows from the caller.
 ///
 /// Positive response to a [`RequestDownloadRequest`] indicating the server is ready to receive data.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct RequestDownloadResponse<'d> {
     /// Maximum number of bytes per [`TransferDataRequest`](crate::TransferDataRequest).
     ///
     /// The on-wire `lengthFormatIdentifier` nibble is derived from this slice's length
     /// at encode time, so the declared length can never disagree with the bytes present.
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub max_number_of_block_length: &'d [u8],
 }
 
@@ -312,5 +316,18 @@ mod tests {
         let block = [0x10u8, 0x00, 0x00];
         let resp = RequestDownloadResponse::new(&block);
         assert_encode_size_agrees(&resp);
+    }
+
+    #[test]
+    fn derive_contract() {
+        use crate::test_util::assert_impl_eq;
+        assert_impl_eq::<RequestDownloadRequest>();
+        assert_impl_eq::<RequestDownloadResponse<'static>>();
+        #[cfg(feature = "serde")]
+        {
+            use crate::test_util::assert_impl_serde;
+            assert_impl_serde::<RequestDownloadRequest>();
+            assert_impl_serde::<RequestDownloadResponse<'static>>();
+        }
     }
 }

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -1,7 +1,7 @@
 //! `RequestFileTransfer` (0x38) service implementation
 
 use crate::shared::{DataFormatIdentifier, read_be_uint, write_be_uint};
-use crate::{Decode, Encode, Error, param_length_u128};
+use crate::{Decode, Encode, Error, param_length_u128, NegativeResponseCode};
 
 /// Minimum byte-width (clamped to at least 1) needed to hold the larger of two size
 /// values. Used to derive the on-wire `parameterLength` prefix from the data itself,
@@ -212,6 +212,21 @@ pub enum RequestFileTransferRequest<'a> {
         DataFormatIdentifier,
         SizePayload,
     ),
+}
+
+const REQUEST_FILE_TRANSFER_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] = [
+    NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
+    NegativeResponseCode::ConditionsNotCorrect,
+    NegativeResponseCode::RequestOutOfRange,
+    NegativeResponseCode::UploadDownloadNotAccepted,
+];
+
+impl RequestFileTransferRequest<'_> {
+    /// Get the allowed [`NegativeResponseCode`] variants for this request.
+    #[must_use]
+    pub fn allowed_nack_codes() -> &'static [NegativeResponseCode] {
+        &REQUEST_FILE_TRANSFER_NEGATIVE_RESPONSE_CODES
+    }
 }
 
 ///////////////////////////////////////// - Response - ///////////////////////////////////////////////////
@@ -821,6 +836,13 @@ impl<'a> Decode<'a> for RequestFileTransferResponse<'a> {
 mod request_tests {
     use super::*;
     use crate::test_util::assert_encode_size_agrees;
+    use crate::NegativeResponseCode;
+
+    #[test]
+    fn test_allowed_nack_codes() {
+        let codes = RequestFileTransferRequest::allowed_nack_codes();
+        assert!(codes.contains(&NegativeResponseCode::UploadDownloadNotAccepted));
+    }
 
     #[test]
     fn test_file_operation_mode() {

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -1,7 +1,7 @@
 //! `RequestFileTransfer` (0x38) service implementation
 
 use crate::shared::{DataFormatIdentifier, read_be_uint, write_be_uint};
-use crate::{Decode, Encode, Error, param_length_u128, NegativeResponseCode};
+use crate::{Decode, Encode, Error, NegativeResponseCode, param_length_u128};
 
 /// Minimum byte-width (clamped to at least 1) needed to hold the larger of two size
 /// values. Used to derive the on-wire `parameterLength` prefix from the data itself,
@@ -835,8 +835,8 @@ impl<'a> Decode<'a> for RequestFileTransferResponse<'a> {
 #[cfg(test)]
 mod request_tests {
     use super::*;
-    use crate::test_util::assert_encode_size_agrees;
     use crate::NegativeResponseCode;
+    use crate::test_util::assert_encode_size_agrees;
 
     #[test]
     fn test_allowed_nack_codes() {
@@ -1073,7 +1073,7 @@ mod response_tests {
     }
 
     #[test]
-    const fn derive_contract() {
+    fn derive_contract() {
         use crate::test_util::assert_impl_eq;
 
         // Verify all nine types implement Eq

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -87,7 +87,7 @@ impl TryFrom<u8> for FileOperationMode {
 #[allow(clippy::struct_field_names)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SizePayload {
     /// Specifies the size of the uncompressed file in bytes.
     ///
@@ -136,7 +136,7 @@ impl SizePayload {
 /// [Request]: RequestFileTransferRequest
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NamePayload<'a> {
     /// 0x01 - 0x06, the type of operation to be applied to the file or directory specified in `file_path_and_name`
     pub mode_of_operation: FileOperationMode,
@@ -175,7 +175,7 @@ impl<'a> NamePayload<'a> {
 /// there is no need to use the `TransferData` or [`crate::UdsServiceType::RequestTransferExit`] services.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum RequestFileTransferRequest<'a> {
     /// Add a file to the server
@@ -231,7 +231,7 @@ pub enum RequestFileTransferRequest<'a> {
 /// [Response]: RequestFileTransferResponse
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SentDataPayload<'a> {
     /// This parameter is used by the requestFileTransfer positive response message to inform the client how many
     /// data bytes (maxNumberOfBlockLength) to include in each `TransferData` request message from the client or how
@@ -279,7 +279,7 @@ impl<'a> SentDataPayload<'a> {
 #[allow(clippy::struct_field_names)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FileSizePayload {
     /// Size of the uncompressed file in bytes.
     pub file_size_uncompressed: u128,
@@ -319,7 +319,7 @@ impl FileSizePayload {
 /// [Response]: RequestFileTransferResponse
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DirSizePayload {
     /// Total size of the directory information in bytes.
     pub dir_info_length: u128,
@@ -354,7 +354,7 @@ impl DirSizePayload {
 /// [Response]: RequestFileTransferResponse
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PositionPayload {
     /// Specifies the byte position within the file at which the Tester will resume downloading after an initial download is suspended
     /// A download is suspended when the ECU stops receiving [`crate::TransferDataRequest`] requests and does not receive the
@@ -381,7 +381,7 @@ impl PositionPayload {
 /// `DataFormatIdentifier` - Echoes the value of the request
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum RequestFileTransferResponse<'a> {
     /// Positive response to an [`AddFile`](FileOperationMode::AddFile) request.
@@ -1048,5 +1048,21 @@ mod response_tests {
         let (decoded, _) = RequestFileTransferResponse::decode(&buf[..written]).unwrap();
         assert_eq!(decoded, resp);
         assert_encode_size_agrees(&resp);
+    }
+
+    #[test]
+    const fn derive_contract() {
+        use crate::test_util::assert_impl_eq;
+
+        // Verify all nine types implement Eq
+        assert_impl_eq::<FileOperationMode>();
+        assert_impl_eq::<SizePayload>();
+        assert_impl_eq::<NamePayload<'static>>();
+        assert_impl_eq::<RequestFileTransferRequest<'static>>();
+        assert_impl_eq::<SentDataPayload<'static>>();
+        assert_impl_eq::<FileSizePayload>();
+        assert_impl_eq::<DirSizePayload>();
+        assert_impl_eq::<PositionPayload>();
+        assert_impl_eq::<RequestFileTransferResponse<'static>>();
     }
 }

--- a/src/services/request_transfer_exit.rs
+++ b/src/services/request_transfer_exit.rs
@@ -1,5 +1,5 @@
 //! `RequestTransferExit` (0x37 / 0x77) service implementation.
-use crate::{Decode, Encode, Error};
+use crate::{Decode, Encode, Error, NegativeResponseCode};
 
 macro_rules! transfer_exit_descriptor {
     ($name:ident, $doc:literal) => {
@@ -48,10 +48,31 @@ transfer_exit_descriptor!(
     "Positive response to `RequestTransferExit`, carrying an optional parameter record."
 );
 
+const REQUEST_TRANSFER_EXIT_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] = [
+    NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
+    NegativeResponseCode::RequestSequenceError,
+    NegativeResponseCode::RequestOutOfRange,
+    NegativeResponseCode::GeneralProgrammingFailure,
+];
+
+impl RequestTransferExitRequest<'_> {
+    /// Get the allowed [`NegativeResponseCode`] variants for this request.
+    #[must_use]
+    pub fn allowed_nack_codes() -> &'static [NegativeResponseCode] {
+        &REQUEST_TRANSFER_EXIT_NEGATIVE_RESPONSE_CODES
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
+    use crate::{Decode, Encode, test_util::assert_encode_size_agrees, NegativeResponseCode};
+
+    #[test]
+    fn test_allowed_nack_codes() {
+        let codes = RequestTransferExitRequest::allowed_nack_codes();
+        assert!(codes.contains(&NegativeResponseCode::RequestSequenceError));
+    }
 
     #[test]
     fn rte_request_round_trips_with_and_without_record() {

--- a/src/services/request_transfer_exit.rs
+++ b/src/services/request_transfer_exit.rs
@@ -66,7 +66,7 @@ impl RequestTransferExitRequest<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Decode, Encode, test_util::assert_encode_size_agrees, NegativeResponseCode};
+    use crate::{Decode, Encode, NegativeResponseCode, test_util::assert_encode_size_agrees};
 
     #[test]
     fn test_allowed_nack_codes() {

--- a/src/services/routine_control.rs
+++ b/src/services/routine_control.rs
@@ -215,8 +215,8 @@ impl<'a> Decode<'a> for RoutineControlResponse<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{Decode, NegativeResponseCode};
     use crate::test_util::{assert_encode_size_agrees, assert_impl_eq};
+    use crate::{Decode, NegativeResponseCode};
 
     #[test]
     fn derive_contract() {
@@ -281,7 +281,9 @@ mod test {
     #[test]
     fn exposes_allowed_nack_codes() {
         assert!(!RoutineControlRequest::allowed_nack_codes().is_empty());
-        assert!(RoutineControlRequest::allowed_nack_codes()
-            .contains(&NegativeResponseCode::SecurityAccessDenied));
+        assert!(
+            RoutineControlRequest::allowed_nack_codes()
+                .contains(&NegativeResponseCode::SecurityAccessDenied)
+        );
     }
 }

--- a/src/services/routine_control.rs
+++ b/src/services/routine_control.rs
@@ -3,7 +3,7 @@
 //! It can also be used to check the ECU's health, erase memory, or other custom manufacturer/supplier routines.
 //! However, some routines may have side effects or require certain preconditions to be met.
 use crate::shared::SuppressablePositiveResponse;
-use crate::{Decode, Encode, Error};
+use crate::{Decode, Encode, Error, NegativeResponseCode};
 
 /// What type of routine control to perform for a [`RoutineControlRequest`].
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -49,6 +49,16 @@ impl TryFrom<u8> for RoutineControlSubFunction {
     }
 }
 
+const ROUTINE_CONTROL_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 7] = [
+    NegativeResponseCode::SubFunctionNotSupported,
+    NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
+    NegativeResponseCode::ConditionsNotCorrect,
+    NegativeResponseCode::RequestSequenceError,
+    NegativeResponseCode::RequestOutOfRange,
+    NegativeResponseCode::SecurityAccessDenied,
+    NegativeResponseCode::GeneralProgrammingFailure,
+];
+
 /// Used by a client to execute a defined sequence of events and obtain any relevant results.
 ///
 /// The 2-byte big-endian routine identifier is decoded into a typed `u16`, followed by
@@ -84,6 +94,12 @@ impl<'d> RoutineControlRequest<'d> {
             routine_id,
             option_record,
         }
+    }
+
+    /// Get the allowed [`NegativeResponseCode`] variants for this request.
+    #[must_use]
+    pub fn allowed_nack_codes() -> &'static [NegativeResponseCode] {
+        &ROUTINE_CONTROL_NEGATIVE_RESPONSE_CODES
     }
 }
 
@@ -199,7 +215,7 @@ impl<'a> Decode<'a> for RoutineControlResponse<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Decode;
+    use crate::{Decode, NegativeResponseCode};
     use crate::test_util::{assert_encode_size_agrees, assert_impl_eq};
 
     #[test]
@@ -260,5 +276,12 @@ mod test {
         // 0x7F (low 7 bits = 0x7F) is a reserved routineControlType
         let bytes = [0x7F, 0xFF, 0x00];
         assert!(<RoutineControlRequest as Decode>::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn exposes_allowed_nack_codes() {
+        assert!(!RoutineControlRequest::allowed_nack_codes().is_empty());
+        assert!(RoutineControlRequest::allowed_nack_codes()
+            .contains(&NegativeResponseCode::SecurityAccessDenied));
     }
 }

--- a/src/services/routine_control.rs
+++ b/src/services/routine_control.rs
@@ -53,6 +53,8 @@ impl TryFrom<u8> for RoutineControlSubFunction {
 ///
 /// The 2-byte big-endian routine identifier is decoded into a typed `u16`, followed by
 /// optional routine input parameters in `option_record`.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct RoutineControlRequest<'d> {
@@ -63,6 +65,7 @@ pub struct RoutineControlRequest<'d> {
     /// The 16-bit routine identifier.
     pub routine_id: u16,
     /// Optional routine input parameters (may be empty).
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub option_record: &'d [u8],
 }
 
@@ -127,6 +130,8 @@ impl<'a> Decode<'a> for RoutineControlRequest<'a> {
 ///
 /// The 2-byte big-endian routine identifier echo is decoded into a typed `u16`, followed
 /// by optional routine status bytes in `status_record`.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct RoutineControlResponse<'d> {
@@ -135,6 +140,7 @@ pub struct RoutineControlResponse<'d> {
     /// The 16-bit routine identifier echoed from the request.
     pub routine_id: u16,
     /// Optional routine status bytes (may be empty).
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub status_record: &'d [u8],
 }
 
@@ -194,7 +200,20 @@ impl<'a> Decode<'a> for RoutineControlResponse<'a> {
 mod test {
     use super::*;
     use crate::Decode;
-    use crate::test_util::assert_encode_size_agrees;
+    use crate::test_util::{assert_encode_size_agrees, assert_impl_eq};
+
+    #[test]
+    fn derive_contract() {
+        assert_impl_eq::<RoutineControlRequest<'_>>();
+        assert_impl_eq::<RoutineControlResponse<'_>>();
+
+        #[cfg(feature = "serde")]
+        {
+            use crate::test_util::assert_impl_serde;
+            assert_impl_serde::<RoutineControlRequest<'_>>();
+            assert_impl_serde::<RoutineControlResponse<'_>>();
+        }
+    }
 
     #[test]
     fn rc_request_round_trips_with_suppress() {

--- a/src/services/security_access.rs
+++ b/src/services/security_access.rs
@@ -28,7 +28,7 @@ impl SecurityAccessLevel {
 
     /// The raw level byte (always `0x00..=0x7F`).
     #[must_use]
-    pub const fn get(self) -> u8 {
+    pub const fn value(self) -> u8 {
         self.0
     }
 }
@@ -75,8 +75,8 @@ impl From<SecurityAccessType> for u8 {
     fn from(value: SecurityAccessType) -> Self {
         match value {
             SecurityAccessType::ISOSAEReserved(val) => val,
-            SecurityAccessType::RequestSeed(level) => level.get(),
-            SecurityAccessType::SendKey(level) => level.get(),
+            SecurityAccessType::RequestSeed(level) => level.value(),
+            SecurityAccessType::SendKey(level) => level.value(),
             SecurityAccessType::ISO26021_2Values => 0x5F,
             SecurityAccessType::ISO26021_2SendKeyValues => 0x60,
             SecurityAccessType::SystemSupplierSpecific(val) => val,
@@ -173,10 +173,19 @@ mod security_access_type_tests {
     }
 
     #[test]
+    fn level_value_is_const_accessor() {
+        const V: u8 = match SecurityAccessLevel::new(0x03) {
+            Ok(l) => l.value(),
+            Err(_) => 0xFF,
+        };
+        assert_eq!(V, 0x03);
+    }
+
+    #[test]
     fn security_access_level_rejects_sprmib_colliding_values() {
         // 0x00..=0x7F are constructible; 0x80..=0xFF (SPRMIB bit set) are rejected.
         for value in 0x00..=0x7F {
-            assert_eq!(SecurityAccessLevel::new(value).unwrap().get(), value);
+            assert_eq!(SecurityAccessLevel::new(value).unwrap().value(), value);
         }
         for value in 0x80..=0xFF {
             assert!(matches!(

--- a/src/services/security_access.rs
+++ b/src/services/security_access.rs
@@ -232,6 +232,8 @@ const SECURITY_ACCESS_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 8] = [
 /// Suppressing a positive response to this request is allowed.
 ///
 /// Zero-alloc request for security access. Borrows from the caller.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct SecurityAccessRequest<'d> {
@@ -240,6 +242,7 @@ pub struct SecurityAccessRequest<'d> {
     /// The requested [`SecurityAccessType`].
     pub access_type: SecurityAccessType,
     /// The implementation-defined request data (seed data record or key bytes).
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub request_data: &'d [u8],
 }
 
@@ -299,12 +302,15 @@ impl<'a> Decode<'a> for SecurityAccessRequest<'a> {
 }
 
 /// Zero-alloc response for security access. Borrows from the caller.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct SecurityAccessResponse<'d> {
     /// The security access type echoed from the request.
     pub access_type: SecurityAccessType,
     /// The security seed bytes (empty for a `SendKey` positive response).
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub security_seed: &'d [u8],
 }
 
@@ -352,9 +358,21 @@ impl<'a> Decode<'a> for SecurityAccessResponse<'a> {
 #[cfg(test)]
 mod request {
     use super::*;
-    use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
+    use crate::{Decode, Encode, test_util::assert_encode_size_agrees, test_util::assert_impl_eq};
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
+
+    #[test]
+    fn derive_contract() {
+        assert_impl_eq::<SecurityAccessRequest<'_>>();
+        assert_impl_eq::<SecurityAccessResponse<'_>>();
+        #[cfg(feature = "serde")]
+        {
+            use crate::test_util::assert_impl_serde;
+            assert_impl_serde::<SecurityAccessRequest<'_>>();
+            assert_impl_serde::<SecurityAccessResponse<'_>>();
+        }
+    }
 
     #[cfg(feature = "alloc")]
     #[test]

--- a/src/services/transfer_data.rs
+++ b/src/services/transfer_data.rs
@@ -1,6 +1,15 @@
 //! `TransferData` (0x36) service implementation
 
-use crate::{Decode, Encode, Error};
+use crate::{Decode, Encode, Error, NegativeResponseCode};
+
+const TRANSFER_DATA_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 6] = [
+    NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
+    NegativeResponseCode::RequestSequenceError,
+    NegativeResponseCode::RequestOutOfRange,
+    NegativeResponseCode::TransferDataSuspended,
+    NegativeResponseCode::GeneralProgrammingFailure,
+    NegativeResponseCode::WrongBlockSequenceCounter,
+];
 
 /// A request to the server to transfer data (either upload or download)
 ///
@@ -42,6 +51,12 @@ impl<'d> TransferDataRequest<'d> {
             block_sequence_counter,
             data,
         }
+    }
+
+    /// Get the allowed [`NegativeResponseCode`] variants for this request.
+    #[must_use]
+    pub fn allowed_nack_codes() -> &'static [NegativeResponseCode] {
+        &TRANSFER_DATA_NEGATIVE_RESPONSE_CODES
     }
 }
 
@@ -130,9 +145,15 @@ impl<'a> Decode<'a> for TransferDataResponse<'a> {
 #[cfg(test)]
 mod request {
     use super::*;
-    use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
+    use crate::{Decode, Encode, test_util::assert_encode_size_agrees, NegativeResponseCode};
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
+
+    #[test]
+    fn test_allowed_nack_codes() {
+        let codes = TransferDataRequest::allowed_nack_codes();
+        assert!(codes.contains(&NegativeResponseCode::WrongBlockSequenceCounter));
+    }
 
     #[test]
     fn derive_contract() {

--- a/src/services/transfer_data.rs
+++ b/src/services/transfer_data.rs
@@ -22,11 +22,15 @@ use crate::{Decode, Encode, Error};
 /// Step 3 Response: The server sends a [`crate::UdsServiceType::RequestTransferExit`] response message to the client (RID 0x77)
 ///
 /// Zero-alloc request to transfer data. Borrows from the caller.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct TransferDataRequest<'d> {
     /// Block sequence counter (wraps 0xFF → 0x00).
     pub block_sequence_counter: u8,
     /// The data to be transferred.
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub data: &'d [u8],
 }
 
@@ -71,11 +75,15 @@ impl<'a> Decode<'a> for TransferDataRequest<'a> {
 }
 
 /// Zero-alloc response for transfer data. Borrows from the caller.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct TransferDataResponse<'d> {
     /// Echo of the block sequence counter.
     pub block_sequence_counter: u8,
     /// Response data (vendor-specific).
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub data: &'d [u8],
 }
 
@@ -125,6 +133,19 @@ mod request {
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
+
+    #[test]
+    fn derive_contract() {
+        use crate::test_util::assert_impl_eq;
+        assert_impl_eq::<TransferDataRequest<'static>>();
+        assert_impl_eq::<TransferDataResponse<'static>>();
+        #[cfg(feature = "serde")]
+        {
+            use crate::test_util::assert_impl_serde;
+            assert_impl_serde::<TransferDataRequest<'_>>();
+            assert_impl_serde::<TransferDataResponse<'_>>();
+        }
+    }
 
     #[test]
     fn test_transfer_data_request() {

--- a/src/services/transfer_data.rs
+++ b/src/services/transfer_data.rs
@@ -145,7 +145,7 @@ impl<'a> Decode<'a> for TransferDataResponse<'a> {
 #[cfg(test)]
 mod request {
     use super::*;
-    use crate::{Decode, Encode, test_util::assert_encode_size_agrees, NegativeResponseCode};
+    use crate::{Decode, Encode, NegativeResponseCode, test_util::assert_encode_size_agrees};
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
 

--- a/src/services/write_data_by_identifier.rs
+++ b/src/services/write_data_by_identifier.rs
@@ -15,6 +15,8 @@ const WRITE_DID_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 5] = [
 /// data record that follows it on the wire.
 ///
 /// See ISO-14229-1:2020, Section 11.7.2.1
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct WriteDataByIdentifierRequest<'d> {
@@ -22,6 +24,7 @@ pub struct WriteDataByIdentifierRequest<'d> {
     /// the big-endian encoding is handled on the wire.
     pub identifier: u16,
     /// The opaque data record written after the identifier.
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub data: &'d [u8],
 }
 
@@ -72,6 +75,8 @@ impl<'a> Decode<'a> for WriteDataByIdentifierRequest<'a> {
 /// Positive response to `WriteDataByIdentifier`: echoes the DID that was written.
 ///
 /// See ISO-14229-1:2020, Section 11.7.3.1
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct WriteDataByIdentifierResponse {
@@ -114,6 +119,19 @@ impl<'a> Decode<'a> for WriteDataByIdentifierResponse {
 mod test {
     use super::*;
     use crate::test_util::assert_encode_size_agrees;
+
+    #[test]
+    fn derive_contract() {
+        use crate::test_util::assert_impl_eq;
+        assert_impl_eq::<WriteDataByIdentifierRequest<'static>>();
+        assert_impl_eq::<WriteDataByIdentifierResponse>();
+        #[cfg(feature = "serde")]
+        {
+            use crate::test_util::assert_impl_serde;
+            assert_impl_serde::<WriteDataByIdentifierRequest<'_>>();
+            assert_impl_serde::<WriteDataByIdentifierResponse>();
+        }
+    }
 
     #[test]
     fn test_write_response_encode() {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -28,3 +28,13 @@ pub(crate) fn assert_encode_size_agrees<T: Encode>(value: &T) {
         "encode consumed {consumed} bytes, encoded_size() is {size}"
     );
 }
+
+/// Compile-time assertion that `T: Eq`. Never called at runtime; instantiating it
+/// in a test forces a compile error until the type derives `Eq`.
+#[allow(dead_code)]
+pub(crate) const fn assert_impl_eq<T: Eq>() {}
+
+/// Compile-time assertion that `T` round-trips serde (borrowed deserialize allowed).
+#[cfg(feature = "serde")]
+#[allow(dead_code)]
+pub(crate) const fn assert_impl_serde<'de, T: serde::Serialize + serde::Deserialize<'de>>() {}


### PR DESCRIPTION
## Summary

A pre-tag consistency/ergonomics sweep of the public API. No behavioral change for conformant wire traffic — this pass touches derives, associated functions, two new named response wrappers, and one accessor rename. Encode/decode of valid frames is byte-for-byte identical.

Spec & plan: `docs/superpowers/specs/2026-07-01-api-consistency-pass-design.md`, `docs/superpowers/plans/2026-07-01-api-consistency-pass.md`.

## What changed

**Tier 1 — uniform derives on the zero-copy borrowed types.** The older POD types already had the full derive treatment; the borrowed (`&'a [u8]`-backed) types did not. Now every `*Request`/`*Response` carries `serde` + `utoipa` cfg-derives, `Eq`, and `#[non_exhaustive]` (with `#[serde(borrow)]` on borrowed fields). `ReadDTCInfoRequest::new` is now `const`. Also added `Eq` to `DTCFormatIdentifier` (a prerequisite that unblocked `ReadDTCInfoResponse: Eq`).

**Tier 2 — `allowed_nack_codes()` completed.** Added to the 6 services that lacked it, so all **15/15** services now expose `fn() -> &'static [NegativeResponseCode]` uniformly.

**Tier 3a — response symmetry.** Introduced named `ClearDiagnosticInfoResponse` and `ReadDataByIdentifierResponse<'a>` types, replacing the bare `Response::ClearDiagnosticInfo` unit variant and the inline `Response::ReadDataByIdentifier(&[u8])`. Every `Response` variant now carries a named, exported, serde-able type.

**Tier 3b — accessor convention.** Standardized scalar-newtype accessors on `const fn value()` (renamed the lone outlier `SecurityAccessLevel::get()`).

## Intentional deviations (reviewed & documented)

- **`ReadDataByIdentifierRequest` did not get serde/utoipa.** Its private `Dids::Native(&[u16])` backing has no borrowed-`Deserialize` impl in serde (only `&[u8]`/`&str` support zero-copy borrow). Carved out and documented inline. The *response* (wrapping `&[u8]`) got full serde.
- **`ClearDiagnosticInfo` decode is now strict.** A positive response with trailing bytes after the SID is now rejected (via `decode_exact`), matching every other response arm. Conformant traffic (`[0x54]`) is unaffected. A test asserts both paths.

## Verification

- `cargo test` green across `default`, `--no-default-features`, `--no-default-features --features alloc`, `--all-features` (163 unit + 3 doctests).
- `cargo clippy --all-features -- -D warnings` and `--no-default-features` clean.
- `cargo fmt --check` clean; `cargo doc --all-features` clean (no `missing_docs`).
- MSRV 1.85.0 and `no_std` build preserved.
- ⚠️ Fuzz smoke (`fuzz_roundtrip`/`fuzz_request_decode`/`fuzz_response_decode`) **not run** — `cargo-fuzz` isn't installed locally. Worth running before the tag since the `Response` enum changed shape.

## Process

Executed task-by-task with a fresh implementer + independent spec/quality review per task, plus a final whole-branch review (no Critical findings). Every derive addition is guarded by a compile-time trait-bound assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)