### PR TITLE
refactor!: apply the C-CASE naming convention and ISO service spellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,97 @@ pre-1.0 crates).
 
 These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
 
+### Changed (API consistency pass)
+
+- **Breaking:** Acronyms in type and variant names now follow the Rust API guideline
+  ([C-CASE](https://rust-lang.github.io/api-guidelines/naming.html)): `Dtc`, `Uds`, `Ecu`,
+  `Obd`, `Edr`, `Iso`, `Sae`, `Vin`, `Rpm`, `WwhObd`, `IsoSae`. The crate previously used
+  both conventions at once — `UdsServiceType` and `DtcAndStatusIter` beside `UDSIdentifier`
+  and `DTCStatusMask`. Type renames:
+
+  | Old                              | New                              |
+  | -------------------------------- | -------------------------------- |
+  | `UDSIdentifier`                  | `UdsIdentifier`                  |
+  | `UDSRoutineIdentifier`           | `UdsRoutineIdentifier`           |
+  | `DTCRecord`                      | `DtcRecord`                      |
+  | `DTCStatusMask`                  | `DtcStatusMask`                  |
+  | `DTCSeverityMask`                | `DtcSeverityMask`                |
+  | `DTCFormatIdentifier`            | `DtcFormatIdentifier`            |
+  | `DTCExtDataRecordNumber`         | `DtcExtDataRecordNumber`         |
+  | `DTCSnapshotRecordNumber`        | `DtcSnapshotRecordNumber`        |
+  | `DTCStoredDataRecordNumber`      | `DtcStoredDataRecordNumber`      |
+  | `DTCFaultDetectionCounterRecord` | `DtcFaultDetectionCounterRecord` |
+  | `ControlDTCSettingRequest`       | `ControlDtcSettingRequest`       |
+  | `ControlDTCSettingResponse`      | `ControlDtcSettingResponse`      |
+  | `ReadDTCInfoRequest`             | `ReadDtcInfoRequest`             |
+  | `ReadDTCInfoResponse`            | `ReadDtcInfoResponse`            |
+  | `ReadDTCInfoSubFunction`         | `ReadDtcInfoSubFunction`         |
+
+  Enum variants follow the same rule mechanically (`UdsServiceType::ReadDTCInfo` ->
+  `ReadDtcInfo`, `ISOSAEReserved` -> `IsoSaeReserved` across all nine enums that
+  declare it, and so on). Four variant groups did **not** rename mechanically:
+
+  - `ReadDtcInfoSubFunction` variants lose their underscores along with the enum's
+    `#[allow(non_camel_case_types)]`: `ReportDTC_ByStatusMask` -> `ReportDtcByStatusMask`,
+    `ReportWWHOBDDTC_ByMaskRecord` -> `ReportWwhObdDtcByMaskRecord`.
+  - `DtcSeverityMask::DTCClass_0..4` -> `DtcClass0..4`.
+  - `DtcFormatIdentifier` and `SecurityAccessType` variants **keep** the underscores that
+    separate digit groups inside a standard's document number, because those carry meaning:
+    `ISO_11992_4_DTCFormat` -> `Iso11992_4DtcFormat`, `ISO26021_2Values` ->
+    `Iso26021_2Values`. (`non_camel_case_types` permits `_` between digits, so no `allow`
+    is needed.) Trailing sequence numbers do lose theirs:
+    `SAE_J2012_DA_DTCFormat_00` -> `SaeJ2012DaDtcFormat00`.
+  - `FunctionalGroupIdentifier::VODBSystem` -> `VobdSystem`. The old name was a
+    transposition typo; ISO 14229-1 Table D.1 names 0xFE `VOBDSystem`.
+
+  All three `#[allow(non_camel_case_types)]` attributes in the crate are now gone.
+
+- **Breaking:** `UdsServiceType`'s four SID conversions had two naming conventions for one
+  concept and are now symmetric. Standardised on `sid` rather than `byte`, matching both ISO
+  and the crate's existing `Request::Other { sid }` / `NegativeResponse::request_service_sid()`:
+
+  | Old                         | New                 |
+  | --------------------------- | ------------------- |
+  | `service_from_request_byte` | `from_request_sid`  |
+  | `request_service_to_byte`   | `to_request_sid`    |
+  | `response_from_byte`        | `from_response_sid` |
+  | `response_to_byte`          | `to_response_sid`   |
+
+  Both `to_*` methods now document the lossy `0x7F` fallback for
+  `NegativeResponse`/`UnsupportedDiagnosticService`, and point at `Request::Other` /
+  `Response::Other` for lossless pass-through of unmodeled services.
+
+- **Breaking:** `#[non_exhaustive]` added to eleven public types that ISO will grow into, so
+  that later additions are not breaking changes: `ReadDtcInfoSubFunction`, `FileOperationMode`,
+  `DtcExtDataRecordNumber`, `DtcSnapshotRecordNumber`, `DtcFaultDetectionCounterRecord`,
+  `SizePayload`, `NamePayload`, `SentDataPayload`, `FileSizePayload`, `DirSizePayload`,
+  `PositionPayload`. Downstream `match` statements over these need a wildcard arm, and the
+  seven structs must be built through `new()` rather than a struct literal.
+  `ReadDtcInfoSubFunction` is the important one: it has sub-functions the crate does not model
+  yet, so adding one post-tag would otherwise have been breaking.
+
+### Fixed
+
+- `DtcFaultDetectionCounterRecord` is now exported from the crate root. It is the `Item` of
+  the public `DtcFaultDetectionIter`, but had no public path, so callers could iterate it and
+  read its fields yet could not name the type — no `Vec<T>`, no struct field, no function
+  signature. Its two `pub` fields are also documented now; `missing_docs` had never fired on
+  an unreachable type.
+- Four private type aliases no longer appear in public signatures, where rustdoc rendered them
+  as unlinkable names: `DTCFaultDetectionCounter`, `MemorySelection` and
+  `DTCReadinessGroupIdentifier` (all `= u8`) are spelled `u8` with the meaning moved into the
+  field and variant docs, and `DTCStatusAvailabilityMask` (`= DtcStatusMask`) is spelled
+  `DtcStatusMask` with its "bits on = supported by server" semantics moved onto the four
+  `status_availability_mask` fields. This closes the `TODO` above sub-function `0x18`.
+- `RequestTransferExitRequest` and `RequestTransferExitResponse` now derive `serde` and
+  `utoipa` support like every other public request/response type. Enabling the `serde` feature
+  previously left these two types unserializable.
+
+### Removed
+
+- The `serde_bytes` optional dependency. The `serde` feature activated it, but the crate never
+  referenced it.
+
 ### Changed
 
 - **Breaking:** `Error::InsufficientData` now carries an `automotive_wire_codec::Incomplete`

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ you need to keep before the buffer is reused.
 ## Service coverage
 
 These services decode into typed \[`Request`\]/\[`Response`\] variants: `DiagnosticSessionControl`,
-`EcuReset`, `SecurityAccess`, `CommunicationControl`, `TesterPresent`, `ControlDTCSettings`,
-`ReadDataByIdentifier`, `WriteDataByIdentifier`, `ClearDiagnosticInfo`, `ReadDTCInfo`,
+`EcuReset`, `SecurityAccess`, `CommunicationControl`, `TesterPresent`, `ControlDtcSetting`,
+`ReadDataByIdentifier`, `WriteDataByIdentifier`, `ClearDiagnosticInfo`, `ReadDtcInfo`,
 `RoutineControl`, `RequestDownload`, `TransferData`, `RequestTransferExit`, `RequestFileTransfer`,
 and `NegativeResponse`.
 

--- a/src/dtc/ext_data.rs
+++ b/src/dtc/ext_data.rs
@@ -1,14 +1,14 @@
 use crate::{Decode, Encode, Error, Incomplete};
 use automotive_wire_codec::write_u8;
 
-/// The `DTCExtDataRecordNumber` is used in the request message to get a stored `DTCExtDataRecord`
+/// The `DtcExtDataRecordNumber` is used in the request message to get a stored `DTCExtDataRecord`
 /// It's used to specify the type of `DTCExtDataRecord` to be reported.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DTCExtDataRecordNumber {
+pub enum DtcExtDataRecordNumber {
     /// ISO/SAE reserved record numbers (`0x00`, `0xF0-0xFD`).
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
 
     /// Vehicle manufacturer-specific stored `DTCExtDataRecord`s
     ///
@@ -19,31 +19,31 @@ pub enum DTCExtDataRecordNumber {
     /// The values are specified in SAE J1979-DA.
     ///
     /// 0x90-0x9F
-    RegulatedEmissionsOBDDTCExtDataRecords(u8),
+    RegulatedEmissionsObdDtcExtDataRecords(u8),
 
-    /// The `DTCExtDataRecordNumber` parameter is used to specify the DTC number of the `DTCExtendedData` record to be reported.
+    /// The `DtcExtDataRecordNumber` parameter is used to specify the DTC number of the `DTCExtendedData` record to be reported.
     ///
     /// 0xA0-0xEF
-    RegulatedDTCExtDataRecords(u8),
+    RegulatedDtcExtDataRecords(u8),
 
     /// Requests the server to report all regulated emissions OBD stored `DTCExtendedDataRecords`.
-    AllRegulatedEmissionsOBDDTCExtDataRecords,
+    AllRegulatedEmissionsObdDtcExtDataRecords,
 
     /// Requests the server to report all stored `DTCExtendedDataRecords`
-    AllDTCExtDataRecords,
+    AllDtcExtDataRecords,
 }
 
-impl DTCExtDataRecordNumber {
-    /// Create a new `DTCExtDataRecordNumber` from a raw byte, mapping it to the correct variant.
+impl DtcExtDataRecordNumber {
+    /// Create a new `DtcExtDataRecordNumber` from a raw byte, mapping it to the correct variant.
     #[must_use]
     pub fn new(value: u8) -> Self {
         match value {
-            0x00 | 0xF0..=0xFD => Self::ISOSAEReserved(value),
+            0x00 | 0xF0..=0xFD => Self::IsoSaeReserved(value),
             0x01..=0x8F => Self::VehicleManufacturer(value),
-            0x90..=0x9F => Self::RegulatedEmissionsOBDDTCExtDataRecords(value),
-            0xA0..=0xEF => Self::RegulatedDTCExtDataRecords(value),
-            0xFE => Self::AllRegulatedEmissionsOBDDTCExtDataRecords,
-            0xFF => Self::AllDTCExtDataRecords,
+            0x90..=0x9F => Self::RegulatedEmissionsObdDtcExtDataRecords(value),
+            0xA0..=0xEF => Self::RegulatedDtcExtDataRecords(value),
+            0xFE => Self::AllRegulatedEmissionsObdDtcExtDataRecords,
+            0xFF => Self::AllDtcExtDataRecords,
         }
     }
 
@@ -52,23 +52,23 @@ impl DTCExtDataRecordNumber {
     #[allow(clippy::match_same_arms)]
     pub const fn value(&self) -> u8 {
         match self {
-            Self::ISOSAEReserved(value) => *value,
+            Self::IsoSaeReserved(value) => *value,
             Self::VehicleManufacturer(value) => *value,
-            Self::RegulatedEmissionsOBDDTCExtDataRecords(value) => *value,
-            Self::RegulatedDTCExtDataRecords(value) => *value,
-            Self::AllRegulatedEmissionsOBDDTCExtDataRecords => 0xFE,
-            Self::AllDTCExtDataRecords => 0xFF,
+            Self::RegulatedEmissionsObdDtcExtDataRecords(value) => *value,
+            Self::RegulatedDtcExtDataRecords(value) => *value,
+            Self::AllRegulatedEmissionsObdDtcExtDataRecords => 0xFE,
+            Self::AllDtcExtDataRecords => 0xFF,
         }
     }
 }
 
-impl PartialEq<u8> for DTCExtDataRecordNumber {
+impl PartialEq<u8> for DtcExtDataRecordNumber {
     fn eq(&self, other: &u8) -> bool {
         self.value() == *other
     }
 }
 
-impl Encode for DTCExtDataRecordNumber {
+impl Encode for DtcExtDataRecordNumber {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
@@ -76,7 +76,7 @@ impl Encode for DTCExtDataRecordNumber {
     }
 }
 
-impl<'a> Decode<'a> for DTCExtDataRecordNumber {
+impl<'a> Decode<'a> for DtcExtDataRecordNumber {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
@@ -97,15 +97,15 @@ mod tests {
 
     #[test]
     fn record_number() {
-        let record_number = DTCExtDataRecordNumber::new(0x00);
-        assert_eq!(record_number, DTCExtDataRecordNumber::ISOSAEReserved(0x00));
+        let record_number = DtcExtDataRecordNumber::new(0x00);
+        assert_eq!(record_number, DtcExtDataRecordNumber::IsoSaeReserved(0x00));
         assert_eq!(record_number.value(), 0x00);
     }
 
     #[test]
     fn encode_ext_data_record_number() {
         use crate::test_util::assert_encode_size_agrees;
-        let n = DTCExtDataRecordNumber::new(0x90);
+        let n = DtcExtDataRecordNumber::new(0x90);
         let mut buf = [0u8; 4];
         let written = crate::Encode::encode(&n, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(written, 1);

--- a/src/dtc/snapshot.rs
+++ b/src/dtc/snapshot.rs
@@ -9,7 +9,7 @@ use automotive_wire_codec::write_u8;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DTCSnapshotRecordNumber {
+pub enum DtcSnapshotRecordNumber {
     /// Reserved for Legislative purposes
     Reserved(u8),
     /// Indicates the number of the specific `DTCSnapshot` data record requested
@@ -18,8 +18,8 @@ pub enum DTCSnapshotRecordNumber {
     All,
 }
 
-impl DTCSnapshotRecordNumber {
-    /// Create a `DTCSnapshotRecordNumber`, classifying the raw byte into `Reserved`
+impl DtcSnapshotRecordNumber {
+    /// Create a `DtcSnapshotRecordNumber`, classifying the raw byte into `Reserved`
     /// (`0x00`/`0xF0`), `All` (`0xFF`), or `Number`. Every byte is accepted (decoding is
     /// deliberately liberal); no value is rejected.
     #[must_use]
@@ -35,20 +35,20 @@ impl DTCSnapshotRecordNumber {
     #[allow(clippy::match_same_arms)]
     pub const fn value(&self) -> u8 {
         match self {
-            DTCSnapshotRecordNumber::Reserved(value) => *value,
-            DTCSnapshotRecordNumber::Number(value) => *value,
-            DTCSnapshotRecordNumber::All => 0xFF,
+            DtcSnapshotRecordNumber::Reserved(value) => *value,
+            DtcSnapshotRecordNumber::Number(value) => *value,
+            DtcSnapshotRecordNumber::All => 0xFF,
         }
     }
 }
 
-impl PartialEq<u8> for DTCSnapshotRecordNumber {
+impl PartialEq<u8> for DtcSnapshotRecordNumber {
     fn eq(&self, other: &u8) -> bool {
         self.value() == *other
     }
 }
 
-impl Encode for DTCSnapshotRecordNumber {
+impl Encode for DtcSnapshotRecordNumber {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
@@ -56,7 +56,7 @@ impl Encode for DTCSnapshotRecordNumber {
     }
 }
 
-impl<'a> Decode<'a> for DTCSnapshotRecordNumber {
+impl<'a> Decode<'a> for DtcSnapshotRecordNumber {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
@@ -76,18 +76,18 @@ mod tests {
 
     #[test]
     fn snapshot_record_number() {
-        let record = DTCSnapshotRecordNumber::new(0x01);
+        let record = DtcSnapshotRecordNumber::new(0x01);
         assert_eq!(record.value(), 0x01);
-        assert_eq!(record, DTCSnapshotRecordNumber::Number(0x01));
+        assert_eq!(record, DtcSnapshotRecordNumber::Number(0x01));
 
-        let all = DTCSnapshotRecordNumber::new(0xFF);
-        assert_eq!(all, DTCSnapshotRecordNumber::All);
+        let all = DtcSnapshotRecordNumber::new(0xFF);
+        assert_eq!(all, DtcSnapshotRecordNumber::All);
     }
 
     #[test]
     fn encode_snapshot_record_number() {
         use crate::test_util::assert_encode_size_agrees;
-        let n = DTCSnapshotRecordNumber::new(0x02);
+        let n = DtcSnapshotRecordNumber::new(0x02);
         let mut buf = [0u8; 4];
         let written = crate::Encode::encode(&n, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(written, 1);

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -5,39 +5,39 @@ use automotive_wire_codec::{write_all, write_u8};
 
 /// Bit-packed DTC status information used by the `ReadDTCInformation` service
 ///
-/// `DTCStatusMask` (1 byte)
+/// `DtcStatusMask` (1 byte)
 /// 8 DTC status bits. Refer to D.2
 /// A DTC status matches the mask if any one of the DTCs actual status bits is set to `1`
 /// and the corresponding on in the mask is set to 1
-/// if( `DTCStatusMask` & `DTCStatus` = !0) is a match
+/// if( `DtcStatusMask` & `DTCStatus` = !0) is a match
 ///
 /// Server note:
 ///     If the mask uses bits that the server does not support,
 ///     the server shall process the bits it does support and ignore the rest
 ///
 /// ```
-/// use uds_protocol::{DTCStatusMask, ReadDTCInfoSubFunction};
-/// // Get DTCs with TestFailed and PendingDTC statuses
-/// let dtc_status = DTCStatusMask::TestFailed | DTCStatusMask::PendingDTC;
-/// let dtc_subfunction = ReadDTCInfoSubFunction::ReportNumberOfDTC_ByStatusMask(dtc_status);
+/// use uds_protocol::{DtcStatusMask, ReadDtcInfoSubFunction};
+/// // Get DTCs with TestFailed and PendingDtc statuses
+/// let dtc_status = DtcStatusMask::TestFailed | DtcStatusMask::PendingDtc;
+/// let dtc_subfunction = ReadDtcInfoSubFunction::ReportNumberOfDtcByStatusMask(dtc_status);
 /// ```
 ///
 /// Per DTC statuses
 ///
 /// | DTC Status Bit | DTC Status Name | Bit state after ClearDiagnosticInformation|
 /// | - | ------------------------------ | --- |
-/// | 0 | [`TestFailed`](DTCStatusMask::TestFailed)                         | **0** |
-/// | 1 | [`TestFailedThisOperationCycle`](DTCStatusMask::TestFailedThisOperationCycle)       | **0** |
-/// | 2 | [`PendingDTC`](DTCStatusMask::PendingDTC)                         | **0** |
-/// | 3 | [`ConfirmedDTC`](DTCStatusMask::ConfirmedDTC)                       | **0** |
-/// | 4 | [`TestNotCompletedSinceLastClear`](DTCStatusMask::TestNotCompletedSinceLastClear)     | **1** |
-/// | 5 | [`TestFailedSinceLastClear`](DTCStatusMask::TestFailedSinceLastClear)           | **0** |
-/// | 6 | [`TestNotCompletedThisOperationCycle`](DTCStatusMask::TestNotCompletedThisOperationCycle) | **1** |
-/// | 7 | [`WarningIndicatorRequested`](DTCStatusMask::WarningIndicatorRequested)          | **0** |
+/// | 0 | [`TestFailed`](DtcStatusMask::TestFailed)                         | **0** |
+/// | 1 | [`TestFailedThisOperationCycle`](DtcStatusMask::TestFailedThisOperationCycle)       | **0** |
+/// | 2 | [`PendingDtc`](DtcStatusMask::PendingDtc)                         | **0** |
+/// | 3 | [`ConfirmedDtc`](DtcStatusMask::ConfirmedDtc)                       | **0** |
+/// | 4 | [`TestNotCompletedSinceLastClear`](DtcStatusMask::TestNotCompletedSinceLastClear)     | **1** |
+/// | 5 | [`TestFailedSinceLastClear`](DtcStatusMask::TestFailedSinceLastClear)           | **0** |
+/// | 6 | [`TestNotCompletedThisOperationCycle`](DtcStatusMask::TestNotCompletedThisOperationCycle) | **1** |
+/// | 7 | [`WarningIndicatorRequested`](DtcStatusMask::WarningIndicatorRequested)          | **0** |
 #[bitmask(u8)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub enum DTCStatusMask {
+pub enum DtcStatusMask {
     /// Status of the most recently performed test.
     ///
     /// Bit state definition:
@@ -62,7 +62,7 @@ pub enum DTCStatusMask {
     /// Bit state definition:
     /// * 0 -  Test passed **with no failure** after completing a cycle
     /// * 1 -  Test failed during the current operation cycle
-    PendingDTC,
+    PendingDtc,
 
     /// Indicates whether a malfunction was detected enough times to warrant the DTC being stored
     /// in long term memory. This doesn't mean that the DTC failure is present at the time of the request.
@@ -71,7 +71,7 @@ pub enum DTCStatusMask {
     /// Bit state definition:
     /// * 0 - DTC has **never been confirmed** since last `ClearDiagnosticInformation`, or after aging criteria have been met
     /// * 1 - DTC has been confirmed at least once
-    ConfirmedDTC,
+    ConfirmedDtc,
 
     /// Indicates whether a test has run and completed since last `ClearDiagnosticInformation`
     /// Will not reset to 1 by any method other than calling `ClearDiagnosticInformation`
@@ -107,14 +107,14 @@ pub enum DTCStatusMask {
     WarningIndicatorRequested,
 }
 
-impl Encode for DTCStatusMask {
+impl Encode for DtcStatusMask {
     type Error = crate::Error;
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
         write_u8(writer, self.bits()).map_err(Error::io)
     }
 }
 
-impl<'a> Decode<'a> for DTCStatusMask {
+impl<'a> Decode<'a> for DtcStatusMask {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
@@ -130,62 +130,61 @@ impl<'a> Decode<'a> for DTCStatusMask {
 
 /// Specifies the format of the DTC reported by the server.
 ///
-/// A given server shall only support one `DTCFormatIdentifier`.
-#[allow(non_camel_case_types)]
+/// A given server shall only support one `DtcFormatIdentifier`.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 #[repr(u8)]
-pub enum DTCFormatIdentifier {
+pub enum DtcFormatIdentifier {
     /// Defined in [SAE J2012-DA](<https://www.sae.org/standards/content/j2012da_202403/>) DTC Format
-    SAE_J2012_DA_DTCFormat_00 = 0x00,
+    SaeJ2012DaDtcFormat00 = 0x00,
 
     /// reported for `DTCAndStatusRecord`
-    ISO_14229_1_DTCFormat = 0x01,
+    Iso14229_1DtcFormat = 0x01,
 
     /// Defined in [SAE J1939-73](<https://www.sae.org/standards/content/j1939/73_202208/>)
-    SAE_J1939_73_DTCFormat = 0x02,
+    SaeJ1939_73DtcFormat = 0x02,
 
     /// Defined in [ISO-11992](<https://www.iso.org/standard/33992.html>)
-    ISO_11992_4_DTCFormat = 0x03,
+    Iso11992_4DtcFormat = 0x03,
 
     /// Defined in SAE J2012-DA](<https://www.sae.org/standards/content/j2012da_202403/>)
-    SAE_J2012_DA_DTCFormat_04 = 0x04,
+    SaeJ2012DaDtcFormat04 = 0x04,
 
     /// Reserved for future usage
     /// 0x05 - 0xFF
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
 }
 
-impl From<u8> for DTCFormatIdentifier {
+impl From<u8> for DtcFormatIdentifier {
     fn from(value: u8) -> Self {
         match value {
-            0x00 => DTCFormatIdentifier::SAE_J2012_DA_DTCFormat_00,
-            0x01 => DTCFormatIdentifier::ISO_14229_1_DTCFormat,
-            0x02 => DTCFormatIdentifier::SAE_J1939_73_DTCFormat,
-            0x03 => DTCFormatIdentifier::ISO_11992_4_DTCFormat,
-            0x04 => DTCFormatIdentifier::SAE_J2012_DA_DTCFormat_04,
-            val => DTCFormatIdentifier::ISOSAEReserved(val),
+            0x00 => DtcFormatIdentifier::SaeJ2012DaDtcFormat00,
+            0x01 => DtcFormatIdentifier::Iso14229_1DtcFormat,
+            0x02 => DtcFormatIdentifier::SaeJ1939_73DtcFormat,
+            0x03 => DtcFormatIdentifier::Iso11992_4DtcFormat,
+            0x04 => DtcFormatIdentifier::SaeJ2012DaDtcFormat04,
+            val => DtcFormatIdentifier::IsoSaeReserved(val),
         }
     }
 }
 
-impl From<DTCFormatIdentifier> for u8 {
-    fn from(val: DTCFormatIdentifier) -> Self {
+impl From<DtcFormatIdentifier> for u8 {
+    fn from(val: DtcFormatIdentifier) -> Self {
         match val {
-            DTCFormatIdentifier::SAE_J2012_DA_DTCFormat_00 => 0x00,
-            DTCFormatIdentifier::ISO_14229_1_DTCFormat => 0x01,
-            DTCFormatIdentifier::SAE_J1939_73_DTCFormat => 0x02,
-            DTCFormatIdentifier::ISO_11992_4_DTCFormat => 0x03,
-            DTCFormatIdentifier::SAE_J2012_DA_DTCFormat_04 => 0x04,
-            DTCFormatIdentifier::ISOSAEReserved(value) => value, // Default value for reserved
+            DtcFormatIdentifier::SaeJ2012DaDtcFormat00 => 0x00,
+            DtcFormatIdentifier::Iso14229_1DtcFormat => 0x01,
+            DtcFormatIdentifier::SaeJ1939_73DtcFormat => 0x02,
+            DtcFormatIdentifier::Iso11992_4DtcFormat => 0x03,
+            DtcFormatIdentifier::SaeJ2012DaDtcFormat04 => 0x04,
+            DtcFormatIdentifier::IsoSaeReserved(value) => value, // Default value for reserved
         }
     }
 }
 
 /// Use to clear all DTCs in a [`crate::ClearDiagnosticInfoRequest`]
-pub const CLEAR_ALL_DTCS: DTCRecord = DTCRecord {
+pub const CLEAR_ALL_DTCS: DtcRecord = DtcRecord {
     high_byte: 0xFF,
     middle_byte: 0xFF,
     low_byte: 0xFF,
@@ -196,14 +195,14 @@ pub const CLEAR_ALL_DTCS: DTCRecord = DTCRecord {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DTCRecord {
+pub struct DtcRecord {
     high_byte: u8,
     middle_byte: u8,
     low_byte: u8,
 }
 
-impl DTCRecord {
-    /// Create a `DTCRecord` from its three component bytes.
+impl DtcRecord {
+    /// Create a `DtcRecord` from its three component bytes.
     #[must_use]
     pub fn new(high_byte: u8, middle_byte: u8, low_byte: u8) -> Self {
         Self {
@@ -214,7 +213,7 @@ impl DTCRecord {
     }
 }
 
-impl From<u32> for DTCRecord {
+impl From<u32> for DtcRecord {
     fn from(value: u32) -> Self {
         Self {
             high_byte: ((value >> 16) & 0xFF) as u8,
@@ -224,15 +223,15 @@ impl From<u32> for DTCRecord {
     }
 }
 
-impl From<DTCRecord> for u32 {
-    fn from(value: DTCRecord) -> Self {
+impl From<DtcRecord> for u32 {
+    fn from(value: DtcRecord) -> Self {
         (u32::from(value.high_byte) << 16)
             | (u32::from(value.middle_byte) << 8)
             | u32::from(value.low_byte)
     }
 }
 
-impl Encode for DTCRecord {
+impl Encode for DtcRecord {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
@@ -240,7 +239,7 @@ impl Encode for DTCRecord {
     }
 }
 
-impl<'a> Decode<'a> for DTCRecord {
+impl<'a> Decode<'a> for DtcRecord {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
@@ -261,7 +260,7 @@ impl<'a> Decode<'a> for DTCRecord {
     }
 }
 
-impl<'a> DecodeIter<'a> for DTCRecord {
+impl<'a> DecodeIter<'a> for DtcRecord {
     type Error = crate::Error;
     const WIRE_SIZE: Option<usize> = Some(3);
 
@@ -288,7 +287,7 @@ pub enum FunctionalGroupIdentifier {
     /// 0x34 to 0xCF
     /// 0xE0 to 0xFD
     /// 0xFF
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
     /// 0x33
     EmissionsSystemGroup,
     /// 0xD0
@@ -299,7 +298,7 @@ pub enum FunctionalGroupIdentifier {
     LegislativeSystemGroup(u8),
 
     /// 0xFE
-    VODBSystem,
+    VobdSystem,
 }
 
 impl FunctionalGroupIdentifier {
@@ -309,9 +308,9 @@ impl FunctionalGroupIdentifier {
         match self {
             FunctionalGroupIdentifier::EmissionsSystemGroup => 0x33,
             FunctionalGroupIdentifier::SafetySystemGroup => 0xD0,
-            FunctionalGroupIdentifier::VODBSystem => 0xFE,
+            FunctionalGroupIdentifier::VobdSystem => 0xFE,
             FunctionalGroupIdentifier::LegislativeSystemGroup(value)
-            | FunctionalGroupIdentifier::ISOSAEReserved(value) => *value,
+            | FunctionalGroupIdentifier::IsoSaeReserved(value) => *value,
         }
     }
 }
@@ -321,9 +320,9 @@ impl From<u8> for FunctionalGroupIdentifier {
         match value {
             0x33 => FunctionalGroupIdentifier::EmissionsSystemGroup,
             0xD0 => FunctionalGroupIdentifier::SafetySystemGroup,
-            0xFE => FunctionalGroupIdentifier::VODBSystem,
+            0xFE => FunctionalGroupIdentifier::VobdSystem,
             0xD1..=0xDF => FunctionalGroupIdentifier::LegislativeSystemGroup(value),
-            _ => FunctionalGroupIdentifier::ISOSAEReserved(value),
+            _ => FunctionalGroupIdentifier::IsoSaeReserved(value),
         }
     }
 }
@@ -358,30 +357,29 @@ impl<'a> Decode<'a> for FunctionalGroupIdentifier {
 
 /// GTR DTC Class Information
 ///
-/// Bits 7-5 of the DTCSeverityMask/DTCSeverity parameters contain severity information (optional)
-/// Bits 4-0 of the DTCSeverityMask/DTCSeverity parameters contain class information (mandatory)
+/// Bits 7-5 of the DtcSeverityMask/DTCSeverity parameters contain severity information (optional)
+/// Bits 4-0 of the DtcSeverityMask/DTCSeverity parameters contain class information (mandatory)
 ///
 /// DTCCLASS_
-#[allow(non_camel_case_types)]
 #[bitmask(u8)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub enum DTCSeverityMask {
+pub enum DtcSeverityMask {
     // GtrDtcClassInfo
     /// Unclassified
-    DTCClass_0,
+    DtcClass0,
 
     /// Matches GTR module B Class A definition
     /// Malfunction is Class A when On-Board Diagnostic (OBD) threshold limits (OTL) are assumed to be exceeded
     /// It is accepted that the emissions may not be above the OTLs when this class of malfunction occurs
-    DTCClass_1,
+    DtcClass1,
 
     /// Matches GTR module B Class B1 definition
-    DTCClass_2,
+    DtcClass2,
     /// Matches GTR module B Class B2 definition
-    DTCClass_3,
+    DtcClass3,
     /// Matches GTR module B Class C definition
-    DTCClass_4,
+    DtcClass4,
 
     // DTCSeverityInfo section
     /// Failure requests maintenance only
@@ -400,22 +398,18 @@ pub enum DTCSeverityMask {
     CheckImmediately = 0b1000_0000, // bit 7
 }
 
-impl DTCSeverityMask {
+impl DtcSeverityMask {
     /// Returns `true` if at least one DTC class bit (bits 0-4) is set.
     /// Multiple class bits may be set to query multiple DTC classes at once.
     #[must_use]
     pub fn is_valid(&self) -> bool {
         self.intersects(
-            Self::DTCClass_0
-                | Self::DTCClass_1
-                | Self::DTCClass_2
-                | Self::DTCClass_3
-                | Self::DTCClass_4,
+            Self::DtcClass0 | Self::DtcClass1 | Self::DtcClass2 | Self::DtcClass3 | Self::DtcClass4,
         )
     }
 }
 
-impl Encode for DTCSeverityMask {
+impl Encode for DtcSeverityMask {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
@@ -423,7 +417,7 @@ impl Encode for DTCSeverityMask {
     }
 }
 
-impl<'a> Decode<'a> for DTCSeverityMask {
+impl<'a> Decode<'a> for DtcSeverityMask {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
@@ -442,10 +436,10 @@ impl<'a> Decode<'a> for DTCSeverityMask {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DTCStoredDataRecordNumber(u8);
+pub struct DtcStoredDataRecordNumber(u8);
 
-// create a constructor for DTCStoredDataRecordNumber
-impl DTCStoredDataRecordNumber {
+// create a constructor for DtcStoredDataRecordNumber
+impl DtcStoredDataRecordNumber {
     ///
     /// # Errors
     /// Will return `Err(Error::ReservedForLegislativeUse()` if the record number == 0x00 or 0xF0
@@ -467,13 +461,13 @@ impl DTCStoredDataRecordNumber {
     }
 }
 
-impl From<u8> for DTCStoredDataRecordNumber {
+impl From<u8> for DtcStoredDataRecordNumber {
     fn from(value: u8) -> Self {
         Self(value)
     }
 }
 
-impl Encode for DTCStoredDataRecordNumber {
+impl Encode for DtcStoredDataRecordNumber {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
@@ -481,7 +475,7 @@ impl Encode for DTCStoredDataRecordNumber {
     }
 }
 
-impl<'a> Decode<'a> for DTCStoredDataRecordNumber {
+impl<'a> Decode<'a> for DtcStoredDataRecordNumber {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
@@ -502,7 +496,7 @@ mod encode_param_tests {
 
     #[test]
     fn encode_stored_data_record_number() {
-        let n = DTCStoredDataRecordNumber::new(0x05).unwrap();
+        let n = DtcStoredDataRecordNumber::new(0x05).unwrap();
         let mut buf = [0u8; 4];
         let written = Encode::encode(&n, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(written, 1);
@@ -514,18 +508,18 @@ mod encode_param_tests {
     fn stored_data_record_number_construction_is_strict_parsing_is_liberal() {
         // TX: constructing a reserved value is rejected.
         assert!(matches!(
-            DTCStoredDataRecordNumber::new(0xF0),
+            DtcStoredDataRecordNumber::new(0xF0),
             Err(Error::ReservedForLegislativeUse(0xF0))
         ));
         // RX: a reserved value from a foreign implementation still decodes, and value()
         // lets the caller inspect it.
-        let (decoded, _) = <DTCStoredDataRecordNumber as Decode>::decode(&[0xF0]).unwrap();
+        let (decoded, _) = <DtcStoredDataRecordNumber as Decode>::decode(&[0xF0]).unwrap();
         assert_eq!(decoded.value(), 0xF0);
     }
 
     #[test]
     fn encode_severity_mask() {
-        let m = DTCSeverityMask::CheckImmediately;
+        let m = DtcSeverityMask::CheckImmediately;
         let mut buf = [0u8; 4];
         let written = Encode::encode(&m, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(written, 1);
@@ -546,7 +540,7 @@ mod encode_param_tests {
     #[test]
     fn functional_group_identifier_value_does_not_panic_on_reserved() {
         // Regression: value() previously called todo!() for carried-byte variants.
-        let g = FunctionalGroupIdentifier::from(0x10); // -> ISOSAEReserved(0x10)
+        let g = FunctionalGroupIdentifier::from(0x10); // -> IsoSaeReserved(0x10)
         assert_eq!(g.value(), 0x10);
         let g2 = FunctionalGroupIdentifier::from(0xD5); // -> LegislativeSystemGroup(0xD5)
         assert_eq!(g2.value(), 0xD5);
@@ -559,35 +553,35 @@ mod dtc_status_tests {
 
     #[test]
     fn status_mask() {
-        let status_mask = DTCStatusMask::TestFailed | DTCStatusMask::PendingDTC;
+        let status_mask = DtcStatusMask::TestFailed | DtcStatusMask::PendingDtc;
         assert_eq!(status_mask.bits(), 0b0000_0101);
 
-        let status_mask = DTCStatusMask::TestFailedThisOperationCycle
-            | DTCStatusMask::TestNotCompletedSinceLastClear;
+        let status_mask = DtcStatusMask::TestFailedThisOperationCycle
+            | DtcStatusMask::TestNotCompletedSinceLastClear;
 
         assert_eq!(status_mask.bits(), 0b0001_0010);
     }
 
     #[test]
     fn gtr_dtc_class_info() {
-        let dtc_class = DTCSeverityMask::DTCClass_1 | DTCSeverityMask::MaintenanceOnly;
+        let dtc_class = DtcSeverityMask::DtcClass1 | DtcSeverityMask::MaintenanceOnly;
         assert_eq!(dtc_class.bits(), 0b0010_0010);
         assert!(dtc_class.is_valid());
     }
 
     #[test]
     fn dtc_severity_info() {
-        let dtc_severity = DTCSeverityMask::CheckImmediately;
+        let dtc_severity = DtcSeverityMask::CheckImmediately;
         assert_eq!(dtc_severity.bits(), 0b1000_0000);
     }
 
     #[test]
     fn dtc_record_encode_decode() {
-        let record = DTCRecord::new(0x01, 0x02, 0x03);
+        let record = DtcRecord::new(0x01, 0x02, 0x03);
         let mut buf = [0u8; 3];
         let written = Encode::encode(&record, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(written, 3);
-        let (decoded, rest) = <DTCRecord as Decode>::decode(&buf).unwrap();
+        let (decoded, rest) = <DtcRecord as Decode>::decode(&buf).unwrap();
         assert_eq!(decoded, record);
         assert!(rest.is_empty());
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,7 +72,7 @@ pub enum Error {
     /// The routine-control sub-function byte is not a valid [`RoutineControlSubFunction`](crate::RoutineControlSubFunction).
     #[error("Invalid Routine Control Sub-Function: {0}")]
     InvalidRoutineControlSubFunction(u8),
-    /// The DTC-setting byte is not a valid [`DtcSettings`](crate::DtcSettings) value.
+    /// The DTC-setting byte is not a valid [`DtcSettingType`](crate::DtcSettingType) value.
     #[error("Invalid DTC Setting: {0}")]
     InvalidDtcSetting(u8),
     /// The value is reserved for legislative use and must not be used.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,12 @@ pub use automotive_wire_codec::{Decode, DecodeIter, Encode};
 
 mod dtc;
 pub use dtc::{
-    CLEAR_ALL_DTCS, DTCExtDataRecordNumber, DTCFormatIdentifier, DTCRecord, DTCSeverityMask,
-    DTCSnapshotRecordNumber, DTCStatusMask, DTCStoredDataRecordNumber, FunctionalGroupIdentifier,
+    CLEAR_ALL_DTCS, DtcExtDataRecordNumber, DtcFormatIdentifier, DtcRecord, DtcSeverityMask,
+    DtcSnapshotRecordNumber, DtcStatusMask, DtcStoredDataRecordNumber, FunctionalGroupIdentifier,
 };
 
 mod shared;
-pub use shared::{DataFormatIdentifier, NegativeResponseCode, UDSIdentifier, UDSRoutineIdentifier};
+pub use shared::{DataFormatIdentifier, NegativeResponseCode, UdsIdentifier, UdsRoutineIdentifier};
 
 mod request;
 pub use request::Request;
@@ -36,19 +36,18 @@ mod services;
 pub use services::{
     ClearDiagnosticInfoRequest, ClearDiagnosticInfoResponse, CommunicationControlRequest,
     CommunicationControlResponse, CommunicationControlType, CommunicationType,
-    ControlDTCSettingsRequest, ControlDTCSettingsResponse, DTCFaultDetectionCounterRecord,
-    DiagnosticSessionControlRequest, DiagnosticSessionControlResponse, DiagnosticSessionType,
-    DirSizePayload, DtcAndStatusIter, DtcFaultDetectionIter, DtcSettings,
-    DtcSeverityAndStatusIter, EcuResetRequest,
-    EcuResetResponse, FileOperationMode, FileSizePayload, NamePayload, NegativeResponse,
-    PositionPayload, ReadDTCInfoRequest, ReadDTCInfoResponse, ReadDTCInfoSubFunction,
-    ReadDataByIdentifierRequest, ReadDataByIdentifierResponse, RequestDownloadRequest,
-    RequestDownloadResponse, RequestFileTransferRequest, RequestFileTransferResponse,
-    RequestTransferExitRequest, RequestTransferExitResponse, ResetType, RoutineControlRequest,
-    RoutineControlResponse, RoutineControlSubFunction, SecurityAccessLevel, SecurityAccessRequest,
-    SecurityAccessResponse, SecurityAccessType, SentDataPayload, SizePayload, TesterPresentRequest,
-    TesterPresentResponse, TransferDataRequest, TransferDataResponse, WriteDataByIdentifierRequest,
-    WriteDataByIdentifierResponse,
+    ControlDtcSettingRequest, ControlDtcSettingResponse, DiagnosticSessionControlRequest,
+    DiagnosticSessionControlResponse, DiagnosticSessionType, DirSizePayload, DtcAndStatusIter,
+    DtcFaultDetectionCounterRecord, DtcFaultDetectionIter, DtcSettingType,
+    DtcSeverityAndStatusIter, EcuResetRequest, EcuResetResponse, FileOperationMode,
+    FileSizePayload, NamePayload, NegativeResponse, PositionPayload, ReadDataByIdentifierRequest,
+    ReadDataByIdentifierResponse, ReadDtcInfoRequest, ReadDtcInfoResponse, ReadDtcInfoSubFunction,
+    RequestDownloadRequest, RequestDownloadResponse, RequestFileTransferRequest,
+    RequestFileTransferResponse, RequestTransferExitRequest, RequestTransferExitResponse,
+    ResetType, RoutineControlRequest, RoutineControlResponse, RoutineControlSubFunction,
+    SecurityAccessLevel, SecurityAccessRequest, SecurityAccessResponse, SecurityAccessType,
+    SentDataPayload, SizePayload, TesterPresentRequest, TesterPresentResponse, TransferDataRequest,
+    TransferDataResponse, WriteDataByIdentifierRequest, WriteDataByIdentifierResponse,
 };
 
 #[cfg(test)]
@@ -123,11 +122,11 @@ mod no_std_api_tests {
 
     #[test]
     fn fault_detection_counter_record_is_nameable_from_crate_root() {
-        // `DTCFaultDetectionCounterRecord` is the `Item` of `DtcFaultDetectionIter`. Without a
+        // `DtcFaultDetectionCounterRecord` is the `Item` of `DtcFaultDetectionIter`. Without a
         // crate-root path, callers can iterate but cannot name the type — no `Vec<T>`, no struct
         // field, no helper signature. This pins the re-export.
         let data = [0x01, 0x02, 0x03, 0x2A];
-        let record: DTCFaultDetectionCounterRecord =
+        let record: DtcFaultDetectionCounterRecord =
             DtcFaultDetectionIter::new(&data).next().unwrap().unwrap();
         assert_eq!(u32::from(record.dtc_record), 0x01_0203);
         assert_eq!(record.dtc_fault_detection_counter, 0x2A);
@@ -168,7 +167,7 @@ mod no_std_api_tests {
 
     #[test]
     fn read_dtc_info_response_frame_roundtrip() {
-        // ReadDTCInfo response: SID=0x59, sub=0x02, mask=0xFF, then DTC records
+        // ReadDtcInfo response: SID=0x59, sub=0x02, mask=0xFF, then DTC records
         let wire = [0x59, 0x02, 0xFF, 0x01, 0x02, 0x03, 0x0A];
         let (resp, _) = Response::decode(&wire).unwrap();
         let mut buf = [0u8; 16];
@@ -179,12 +178,12 @@ mod no_std_api_tests {
     #[test]
     fn read_dtc_info_request_encodes_through_public_api() {
         // Public-surface construction: types reached via crate root, not shared::/services::.
-        let req = ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ReportDTC_ByStatusMask(
-            DTCStatusMask::from(0xFF),
+        let req = ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::ReportDtcByStatusMask(
+            DtcStatusMask::from(0xFF),
         ));
         let mut buf = [0u8; 8];
         let written = req.encode_to_slice(&mut buf).unwrap();
-        // sub=0x02 ReportDTC_ByStatusMask, mask=0xFF
+        // sub=0x02 ReportDtcByStatusMask, mask=0xFF
         assert_eq!(&buf[..written], &[0x02, 0xFF]);
         assert_eq!(written, req.encoded_size().unwrap());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,10 @@ mod services;
 pub use services::{
     ClearDiagnosticInfoRequest, ClearDiagnosticInfoResponse, CommunicationControlRequest,
     CommunicationControlResponse, CommunicationControlType, CommunicationType,
-    ControlDTCSettingsRequest, ControlDTCSettingsResponse, DiagnosticSessionControlRequest,
-    DiagnosticSessionControlResponse, DiagnosticSessionType, DirSizePayload, DtcAndStatusIter,
-    DtcFaultDetectionIter, DtcSettings, DtcSeverityAndStatusIter, EcuResetRequest,
+    ControlDTCSettingsRequest, ControlDTCSettingsResponse, DTCFaultDetectionCounterRecord,
+    DiagnosticSessionControlRequest, DiagnosticSessionControlResponse, DiagnosticSessionType,
+    DirSizePayload, DtcAndStatusIter, DtcFaultDetectionIter, DtcSettings,
+    DtcSeverityAndStatusIter, EcuResetRequest,
     EcuResetResponse, FileOperationMode, FileSizePayload, NamePayload, NegativeResponse,
     PositionPayload, ReadDTCInfoRequest, ReadDTCInfoResponse, ReadDTCInfoSubFunction,
     ReadDataByIdentifierRequest, ReadDataByIdentifierResponse, RequestDownloadRequest,
@@ -118,6 +119,18 @@ mod no_std_api_tests {
         assert_eq!(records.len(), 2);
         assert_eq!(u32::from(records[0].0), 0x01_0203);
         assert_eq!(u32::from(records[1].0), 0x04_0506);
+    }
+
+    #[test]
+    fn fault_detection_counter_record_is_nameable_from_crate_root() {
+        // `DTCFaultDetectionCounterRecord` is the `Item` of `DtcFaultDetectionIter`. Without a
+        // crate-root path, callers can iterate but cannot name the type — no `Vec<T>`, no struct
+        // field, no helper signature. This pins the re-export.
+        let data = [0x01, 0x02, 0x03, 0x2A];
+        let record: DTCFaultDetectionCounterRecord =
+            DtcFaultDetectionIter::new(&data).next().unwrap().unwrap();
+        assert_eq!(u32::from(record.dtc_record), 0x01_0203);
+        assert_eq!(record.dtc_fault_detection_counter, 0x2A);
     }
 
     #[test]

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,9 +2,9 @@
 use crate::{
     Decode, Encode, Error, Incomplete,
     services::{
-        ClearDiagnosticInfoRequest, CommunicationControlRequest, ControlDTCSettingsRequest,
-        DiagnosticSessionControlRequest, EcuResetRequest, ReadDTCInfoRequest,
-        ReadDataByIdentifierRequest, RequestDownloadRequest, RequestFileTransferRequest,
+        ClearDiagnosticInfoRequest, CommunicationControlRequest, ControlDtcSettingRequest,
+        DiagnosticSessionControlRequest, EcuResetRequest, ReadDataByIdentifierRequest,
+        ReadDtcInfoRequest, RequestDownloadRequest, RequestFileTransferRequest,
         RequestTransferExitRequest, RoutineControlRequest, SecurityAccessRequest,
         TesterPresentRequest, TransferDataRequest, WriteDataByIdentifierRequest,
     },
@@ -25,7 +25,7 @@ pub enum Request<'a> {
     /// Communication control request.
     CommunicationControl(CommunicationControlRequest),
     /// Control DTC settings request.
-    ControlDTCSettings(ControlDTCSettingsRequest),
+    ControlDtcSetting(ControlDtcSettingRequest),
     /// Diagnostic session control request.
     DiagnosticSessionControl(DiagnosticSessionControlRequest),
     /// ECU reset request.
@@ -33,7 +33,7 @@ pub enum Request<'a> {
     /// Read data by identifier request.
     ReadDataByIdentifier(ReadDataByIdentifierRequest<'a>),
     /// Read DTC information request.
-    ReadDTCInfo(ReadDTCInfoRequest),
+    ReadDtcInfo(ReadDtcInfoRequest),
     /// Request download.
     RequestDownload(RequestDownloadRequest),
     /// Request file transfer.
@@ -82,8 +82,8 @@ impl<'a> Decode<'a> for Request<'a> {
             UdsServiceType::CommunicationControl => Self::CommunicationControl(
                 <CommunicationControlRequest as Decode>::decode_exact(payload)?,
             ),
-            UdsServiceType::ControlDTCSettings => Self::ControlDTCSettings(
-                <ControlDTCSettingsRequest as Decode>::decode_exact(payload)?,
+            UdsServiceType::ControlDtcSetting => Self::ControlDtcSetting(
+                <ControlDtcSettingRequest as Decode>::decode_exact(payload)?,
             ),
             UdsServiceType::DiagnosticSessionControl => Self::DiagnosticSessionControl(
                 <DiagnosticSessionControlRequest as Decode>::decode_exact(payload)?,
@@ -94,8 +94,8 @@ impl<'a> Decode<'a> for Request<'a> {
             UdsServiceType::ReadDataByIdentifier => Self::ReadDataByIdentifier(
                 <ReadDataByIdentifierRequest as Decode>::decode_exact(payload)?,
             ),
-            UdsServiceType::ReadDTCInfo => {
-                Self::ReadDTCInfo(<ReadDTCInfoRequest as Decode>::decode_exact(payload)?)
+            UdsServiceType::ReadDtcInfo => {
+                Self::ReadDtcInfo(<ReadDtcInfoRequest as Decode>::decode_exact(payload)?)
             }
             UdsServiceType::RequestDownload => {
                 Self::RequestDownload(<RequestDownloadRequest as Decode>::decode_exact(payload)?)
@@ -142,11 +142,11 @@ impl Encode for Request<'_> {
         let payload = match self {
             Self::ClearDiagnosticInfo(req) => req.encode(writer)?,
             Self::CommunicationControl(req) => req.encode(writer)?,
-            Self::ControlDTCSettings(req) => req.encode(writer)?,
+            Self::ControlDtcSetting(req) => req.encode(writer)?,
             Self::DiagnosticSessionControl(req) => req.encode(writer)?,
             Self::EcuReset(req) => req.encode(writer)?,
             Self::ReadDataByIdentifier(req) => req.encode(writer)?,
-            Self::ReadDTCInfo(req) => req.encode(writer)?,
+            Self::ReadDtcInfo(req) => req.encode(writer)?,
             Self::WriteDataByIdentifier(req) => req.encode(writer)?,
             Self::RequestDownload(req) => req.encode(writer)?,
             Self::RequestFileTransfer(req) => req.encode(writer)?,
@@ -167,7 +167,7 @@ impl Request<'_> {
     pub fn is_positive_response_suppressed(&self) -> bool {
         match self {
             Self::CommunicationControl(req) => req.suppress_positive_response(),
-            Self::ControlDTCSettings(req) => req.suppress_positive_response,
+            Self::ControlDtcSetting(req) => req.suppress_positive_response,
             Self::DiagnosticSessionControl(req) => req.suppress_positive_response,
             Self::EcuReset(req) => req.suppress_positive_response,
             Self::RoutineControl(req) => req.suppress_positive_response,
@@ -183,11 +183,11 @@ impl Request<'_> {
         match self {
             Self::ClearDiagnosticInfo(_) => UdsServiceType::ClearDiagnosticInfo,
             Self::CommunicationControl(_) => UdsServiceType::CommunicationControl,
-            Self::ControlDTCSettings(_) => UdsServiceType::ControlDTCSettings,
+            Self::ControlDtcSetting(_) => UdsServiceType::ControlDtcSetting,
             Self::DiagnosticSessionControl(_) => UdsServiceType::DiagnosticSessionControl,
             Self::EcuReset(_) => UdsServiceType::EcuReset,
             Self::ReadDataByIdentifier(_) => UdsServiceType::ReadDataByIdentifier,
-            Self::ReadDTCInfo(_) => UdsServiceType::ReadDTCInfo,
+            Self::ReadDtcInfo(_) => UdsServiceType::ReadDtcInfo,
             Self::RequestDownload(_) => UdsServiceType::RequestDownload,
             Self::RequestFileTransfer(_) => UdsServiceType::RequestFileTransfer,
             Self::RequestTransferExit(_) => UdsServiceType::RequestTransferExit,

--- a/src/request.rs
+++ b/src/request.rs
@@ -72,7 +72,7 @@ impl<'a> Decode<'a> for Request<'a> {
                 available: buf.len(),
             }));
         }
-        let service = UdsServiceType::service_from_request_byte(buf[0]);
+        let service = UdsServiceType::from_request_sid(buf[0]);
         let payload = &buf[1..];
 
         let request = match service {
@@ -136,7 +136,7 @@ impl Encode for Request<'_> {
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
         let sid = match self {
             Self::Other { sid, .. } => *sid,
-            other => other.service().request_service_to_byte(),
+            other => other.service().to_request_sid(),
         };
         let sid_len = write_u8(writer, sid).map_err(Error::io)?;
         let payload = match self {
@@ -196,7 +196,7 @@ impl Request<'_> {
             Self::TesterPresent(_) => UdsServiceType::TesterPresent,
             Self::TransferData(_) => UdsServiceType::TransferData,
             Self::WriteDataByIdentifier(_) => UdsServiceType::WriteDataByIdentifier,
-            Self::Other { sid, .. } => UdsServiceType::service_from_request_byte(*sid),
+            Self::Other { sid, .. } => UdsServiceType::from_request_sid(*sid),
         }
     }
 }
@@ -211,7 +211,7 @@ mod tests {
         // ECU reset is a fixed 1-byte payload; an extra trailing byte is a
         // malformed frame and must be rejected rather than silently dropped.
         let mut frame = [0u8; 3];
-        frame[0] = UdsServiceType::EcuReset.request_service_to_byte();
+        frame[0] = UdsServiceType::EcuReset.to_request_sid();
         frame[1] = u8::from(ResetType::HardReset);
         frame[2] = 0xAA; // trailing junk
         let result = Request::decode(&frame);

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,7 +1,7 @@
 use crate::{
-    ClearDiagnosticInfoResponse, CommunicationControlResponse, ControlDTCSettingsResponse, Decode,
+    ClearDiagnosticInfoResponse, CommunicationControlResponse, ControlDtcSettingResponse, Decode,
     DiagnosticSessionControlResponse, EcuResetResponse, Encode, Error, Incomplete,
-    NegativeResponse, ReadDTCInfoResponse, ReadDataByIdentifierResponse, RequestDownloadResponse,
+    NegativeResponse, ReadDataByIdentifierResponse, ReadDtcInfoResponse, RequestDownloadResponse,
     RequestFileTransferResponse, RequestTransferExitResponse, RoutineControlResponse,
     SecurityAccessResponse, TesterPresentResponse, TransferDataResponse, UdsServiceType,
     WriteDataByIdentifierResponse,
@@ -19,8 +19,8 @@ pub enum Response<'a> {
     ClearDiagnosticInfo(ClearDiagnosticInfoResponse),
     /// Positive response to `CommunicationControl`.
     CommunicationControl(CommunicationControlResponse),
-    /// Positive response to `ControlDTCSettings`.
-    ControlDTCSettings(ControlDTCSettingsResponse),
+    /// Positive response to `ControlDtcSetting`.
+    ControlDtcSetting(ControlDtcSettingResponse),
     /// Positive response to `DiagnosticSessionControl`.
     DiagnosticSessionControl(DiagnosticSessionControlResponse),
     /// Positive response to `EcuReset`.
@@ -38,7 +38,7 @@ pub enum Response<'a> {
     /// number of data bytes, then repeat on the remainder.
     ReadDataByIdentifier(ReadDataByIdentifierResponse<'a>),
     /// Positive response to `ReadDTCInformation` with lazy iterators.
-    ReadDTCInfo(ReadDTCInfoResponse<'a>),
+    ReadDtcInfo(ReadDtcInfoResponse<'a>),
     /// Positive response to `RequestDownload`.
     RequestDownload(RequestDownloadResponse<'a>),
     /// Positive response to `RequestFileTransfer`.
@@ -87,8 +87,8 @@ impl<'a> Decode<'a> for Response<'a> {
             UdsServiceType::CommunicationControl => Self::CommunicationControl(
                 <CommunicationControlResponse as Decode>::decode_exact(payload)?,
             ),
-            UdsServiceType::ControlDTCSettings => Self::ControlDTCSettings(
-                <ControlDTCSettingsResponse as Decode>::decode_exact(payload)?,
+            UdsServiceType::ControlDtcSetting => Self::ControlDtcSetting(
+                <ControlDtcSettingResponse as Decode>::decode_exact(payload)?,
             ),
             UdsServiceType::DiagnosticSessionControl => Self::DiagnosticSessionControl(
                 <DiagnosticSessionControlResponse as Decode>::decode_exact(payload)?,
@@ -102,8 +102,8 @@ impl<'a> Decode<'a> for Response<'a> {
             UdsServiceType::ReadDataByIdentifier => {
                 Self::ReadDataByIdentifier(ReadDataByIdentifierResponse::new(payload))
             }
-            UdsServiceType::ReadDTCInfo => {
-                Self::ReadDTCInfo(<ReadDTCInfoResponse as Decode>::decode_exact(payload)?)
+            UdsServiceType::ReadDtcInfo => {
+                Self::ReadDtcInfo(<ReadDtcInfoResponse as Decode>::decode_exact(payload)?)
             }
             UdsServiceType::RequestDownload => {
                 Self::RequestDownload(<RequestDownloadResponse as Decode>::decode_exact(payload)?)
@@ -155,19 +155,15 @@ impl Response<'_> {
     fn response_sid(&self) -> u8 {
         match self {
             Self::ClearDiagnosticInfo(_) => UdsServiceType::ClearDiagnosticInfo.to_response_sid(),
-            Self::CommunicationControl(_) => {
-                UdsServiceType::CommunicationControl.to_response_sid()
-            }
-            Self::ControlDTCSettings(_) => UdsServiceType::ControlDTCSettings.to_response_sid(),
+            Self::CommunicationControl(_) => UdsServiceType::CommunicationControl.to_response_sid(),
+            Self::ControlDtcSetting(_) => UdsServiceType::ControlDtcSetting.to_response_sid(),
             Self::DiagnosticSessionControl(_) => {
                 UdsServiceType::DiagnosticSessionControl.to_response_sid()
             }
             Self::EcuReset(_) => UdsServiceType::EcuReset.to_response_sid(),
             Self::NegativeResponse(_) => UdsServiceType::NegativeResponse.to_response_sid(),
-            Self::ReadDataByIdentifier(_) => {
-                UdsServiceType::ReadDataByIdentifier.to_response_sid()
-            }
-            Self::ReadDTCInfo(_) => UdsServiceType::ReadDTCInfo.to_response_sid(),
+            Self::ReadDataByIdentifier(_) => UdsServiceType::ReadDataByIdentifier.to_response_sid(),
+            Self::ReadDtcInfo(_) => UdsServiceType::ReadDtcInfo.to_response_sid(),
             Self::RequestDownload(_) => UdsServiceType::RequestDownload.to_response_sid(),
             Self::RequestFileTransfer(_) => UdsServiceType::RequestFileTransfer.to_response_sid(),
             Self::RequestTransferExit(_) => UdsServiceType::RequestTransferExit.to_response_sid(),
@@ -192,13 +188,13 @@ impl Encode for Response<'_> {
             Self::ClearDiagnosticInfo(resp) => resp.encode(writer)?,
             Self::RequestTransferExit(resp) => resp.encode(writer)?,
             Self::CommunicationControl(resp) => resp.encode(writer)?,
-            Self::ControlDTCSettings(resp) => resp.encode(writer)?,
+            Self::ControlDtcSetting(resp) => resp.encode(writer)?,
             Self::DiagnosticSessionControl(resp) => resp.encode(writer)?,
             Self::EcuReset(resp) => resp.encode(writer)?,
             Self::NegativeResponse(resp) => resp.encode(writer)?,
             Self::ReadDataByIdentifier(resp) => resp.encode(writer)?,
             Self::WriteDataByIdentifier(resp) => resp.encode(writer)?,
-            Self::ReadDTCInfo(resp) => resp.encode(writer)?,
+            Self::ReadDtcInfo(resp) => resp.encode(writer)?,
             Self::RequestDownload(resp) => resp.encode(writer)?,
             Self::RequestFileTransfer(resp) => resp.encode(writer)?,
             Self::RoutineControl(resp) => resp.encode(writer)?,

--- a/src/response.rs
+++ b/src/response.rs
@@ -77,7 +77,7 @@ impl<'a> Decode<'a> for Response<'a> {
                 available: buf.len(),
             }));
         }
-        let service = UdsServiceType::response_from_byte(buf[0]);
+        let service = UdsServiceType::from_response_sid(buf[0]);
         let payload = &buf[1..];
 
         let response = match service {
@@ -146,37 +146,37 @@ impl Response<'_> {
     #[must_use]
     pub fn service(&self) -> UdsServiceType {
         match self {
-            Self::Other { sid, .. } => UdsServiceType::response_from_byte(*sid),
-            other => UdsServiceType::response_from_byte(other.response_sid()),
+            Self::Other { sid, .. } => UdsServiceType::from_response_sid(*sid),
+            other => UdsServiceType::from_response_sid(other.response_sid()),
         }
     }
 
     /// Returns the response service-ID byte that frames this response on the wire.
     fn response_sid(&self) -> u8 {
         match self {
-            Self::ClearDiagnosticInfo(_) => UdsServiceType::ClearDiagnosticInfo.response_to_byte(),
+            Self::ClearDiagnosticInfo(_) => UdsServiceType::ClearDiagnosticInfo.to_response_sid(),
             Self::CommunicationControl(_) => {
-                UdsServiceType::CommunicationControl.response_to_byte()
+                UdsServiceType::CommunicationControl.to_response_sid()
             }
-            Self::ControlDTCSettings(_) => UdsServiceType::ControlDTCSettings.response_to_byte(),
+            Self::ControlDTCSettings(_) => UdsServiceType::ControlDTCSettings.to_response_sid(),
             Self::DiagnosticSessionControl(_) => {
-                UdsServiceType::DiagnosticSessionControl.response_to_byte()
+                UdsServiceType::DiagnosticSessionControl.to_response_sid()
             }
-            Self::EcuReset(_) => UdsServiceType::EcuReset.response_to_byte(),
-            Self::NegativeResponse(_) => UdsServiceType::NegativeResponse.response_to_byte(),
+            Self::EcuReset(_) => UdsServiceType::EcuReset.to_response_sid(),
+            Self::NegativeResponse(_) => UdsServiceType::NegativeResponse.to_response_sid(),
             Self::ReadDataByIdentifier(_) => {
-                UdsServiceType::ReadDataByIdentifier.response_to_byte()
+                UdsServiceType::ReadDataByIdentifier.to_response_sid()
             }
-            Self::ReadDTCInfo(_) => UdsServiceType::ReadDTCInfo.response_to_byte(),
-            Self::RequestDownload(_) => UdsServiceType::RequestDownload.response_to_byte(),
-            Self::RequestFileTransfer(_) => UdsServiceType::RequestFileTransfer.response_to_byte(),
-            Self::RequestTransferExit(_) => UdsServiceType::RequestTransferExit.response_to_byte(),
-            Self::RoutineControl(_) => UdsServiceType::RoutineControl.response_to_byte(),
-            Self::SecurityAccess(_) => UdsServiceType::SecurityAccess.response_to_byte(),
-            Self::TesterPresent(_) => UdsServiceType::TesterPresent.response_to_byte(),
-            Self::TransferData(_) => UdsServiceType::TransferData.response_to_byte(),
+            Self::ReadDTCInfo(_) => UdsServiceType::ReadDTCInfo.to_response_sid(),
+            Self::RequestDownload(_) => UdsServiceType::RequestDownload.to_response_sid(),
+            Self::RequestFileTransfer(_) => UdsServiceType::RequestFileTransfer.to_response_sid(),
+            Self::RequestTransferExit(_) => UdsServiceType::RequestTransferExit.to_response_sid(),
+            Self::RoutineControl(_) => UdsServiceType::RoutineControl.to_response_sid(),
+            Self::SecurityAccess(_) => UdsServiceType::SecurityAccess.to_response_sid(),
+            Self::TesterPresent(_) => UdsServiceType::TesterPresent.to_response_sid(),
+            Self::TransferData(_) => UdsServiceType::TransferData.to_response_sid(),
             Self::WriteDataByIdentifier(_) => {
-                UdsServiceType::WriteDataByIdentifier.response_to_byte()
+                UdsServiceType::WriteDataByIdentifier.to_response_sid()
             }
             Self::Other { sid, .. } => *sid,
         }
@@ -261,7 +261,7 @@ mod tests {
         let frame = [0x99, 0x01, 0x02];
         let (resp, _) = Response::decode(&frame).unwrap();
         assert!(matches!(resp, Response::Other { sid: 0x99, .. }));
-        assert_eq!(resp.service(), UdsServiceType::response_from_byte(0x99));
+        assert_eq!(resp.service(), UdsServiceType::from_response_sid(0x99));
         let mut buf = [0u8; 8];
         let written = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(&buf[..written], &frame); // previously became 0x7F (NegativeResponse)

--- a/src/service.rs
+++ b/src/service.rs
@@ -141,9 +141,11 @@ pub enum UdsServiceType {
 }
 
 impl UdsServiceType {
-    /// Map a request-message service byte to the corresponding [`UdsServiceType`].
+    /// Map a request-message service identifier (SID) byte to its [`UdsServiceType`].
+    ///
+    /// Unrecognised bytes map to [`UdsServiceType::UnsupportedDiagnosticService`].
     #[must_use]
-    pub fn service_from_request_byte(value: u8) -> Self {
+    pub fn from_request_sid(value: u8) -> Self {
         match value {
             0x10 => Self::DiagnosticSessionControl,
             0x11 => Self::EcuReset,
@@ -176,9 +178,16 @@ impl UdsServiceType {
         }
     }
 
-    /// Return the request-message service byte for this service type.
+    /// Return the request-message service identifier (SID) byte for this service type.
+    ///
+    /// # Caveat
+    ///
+    /// [`UdsServiceType::NegativeResponse`] and
+    /// [`UdsServiceType::UnsupportedDiagnosticService`] have no request SID and both return
+    /// `0x7F`, which is not a valid request SID. To re-encode an unmodeled request without
+    /// loss, use [`Request::Other`](crate::Request::Other), which echoes the raw byte.
     #[must_use]
-    pub fn request_service_to_byte(self) -> u8 {
+    pub fn to_request_sid(self) -> u8 {
         match self {
             Self::DiagnosticSessionControl => 0x10,
             Self::EcuReset => 0x11,
@@ -210,9 +219,11 @@ impl UdsServiceType {
             _ => 0x7F,
         }
     }
-    /// Map a positive-response service byte to the corresponding [`UdsServiceType`].
+    /// Map a positive-response service identifier (SID) byte to its [`UdsServiceType`].
+    ///
+    /// Unrecognised bytes map to [`UdsServiceType::UnsupportedDiagnosticService`].
     #[must_use]
-    pub fn response_from_byte(value: u8) -> Self {
+    pub fn from_response_sid(value: u8) -> Self {
         match value {
             0x50 => Self::DiagnosticSessionControl,
             0x51 => Self::EcuReset,
@@ -246,9 +257,12 @@ impl UdsServiceType {
         }
     }
 
-    /// Return the positive-response service byte for this service type.
+    /// Return the positive-response service identifier (SID) byte for this service type.
+    ///
+    /// [`UdsServiceType::UnsupportedDiagnosticService`] has no response SID and returns
+    /// `0x7F`; see [`Response::Other`](crate::Response::Other) for lossless pass-through.
     #[must_use]
-    pub fn response_to_byte(self) -> u8 {
+    pub fn to_response_sid(self) -> u8 {
         match self {
             Self::DiagnosticSessionControl => 0x50,
             Self::EcuReset => 0x51,

--- a/src/service.rs
+++ b/src/service.rs
@@ -301,3 +301,138 @@ impl core::fmt::Display for UdsServiceType {
         write!(f, "{self:?}")
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Every service this crate models, paired with its request and response SID.
+    ///
+    /// Written out rather than derived from the conversions, so the table is an independent
+    /// statement of what ISO 14229-1 assigns and a transposed pair fails instead of agreeing
+    /// with itself. `NegativeResponse` and `UnsupportedDiagnosticService` are absent because
+    /// neither has a request SID.
+    const SERVICES: &[(UdsServiceType, u8, u8)] = &[
+        (UdsServiceType::DiagnosticSessionControl, 0x10, 0x50),
+        (UdsServiceType::EcuReset, 0x11, 0x51),
+        (UdsServiceType::ClearDiagnosticInfo, 0x14, 0x54),
+        (UdsServiceType::ReadDtcInfo, 0x19, 0x59),
+        (UdsServiceType::ReadDataByIdentifier, 0x22, 0x62),
+        (UdsServiceType::ReadMemoryByAddress, 0x23, 0x63),
+        (UdsServiceType::ReadScalingDataByIdentifier, 0x24, 0x64),
+        (UdsServiceType::SecurityAccess, 0x27, 0x67),
+        (UdsServiceType::CommunicationControl, 0x28, 0x68),
+        (UdsServiceType::Authentication, 0x29, 0x69),
+        (UdsServiceType::ReadDataByIdentifierPeriodic, 0x2A, 0x6A),
+        (UdsServiceType::DynamicallyDefinedDataIdentifier, 0x2C, 0x6C),
+        (UdsServiceType::WriteDataByIdentifier, 0x2E, 0x6E),
+        (UdsServiceType::InputOutputControlByIdentifier, 0x2F, 0x6F),
+        (UdsServiceType::RoutineControl, 0x31, 0x71),
+        (UdsServiceType::RequestDownload, 0x34, 0x74),
+        (UdsServiceType::RequestUpload, 0x35, 0x75),
+        (UdsServiceType::TransferData, 0x36, 0x76),
+        (UdsServiceType::RequestTransferExit, 0x37, 0x77),
+        (UdsServiceType::RequestFileTransfer, 0x38, 0x78),
+        (UdsServiceType::TesterPresent, 0x3E, 0x7E),
+        (UdsServiceType::AccessTimingParameters, 0x83, 0xC3),
+        (UdsServiceType::SecuredDataTransmission, 0x84, 0xC4),
+        (UdsServiceType::ControlDtcSetting, 0x85, 0xC5),
+        (UdsServiceType::ResponseOnEvent, 0x86, 0xC6),
+        (UdsServiceType::LinkControl, 0x87, 0xC7),
+        (UdsServiceType::WriteMemoryByAddress, 0x3D, 0x7D),
+    ];
+
+    #[test]
+    fn every_service_maps_to_the_sids_iso_assigns_it() {
+        for &(service, request_sid, response_sid) in SERVICES {
+            assert_eq!(
+                UdsServiceType::to_request_sid(service),
+                request_sid,
+                "{service:?} request SID"
+            );
+            assert_eq!(
+                UdsServiceType::to_response_sid(service),
+                response_sid,
+                "{service:?} response SID"
+            );
+            assert_eq!(
+                UdsServiceType::from_request_sid(request_sid),
+                service,
+                "request SID {request_sid:#04X}"
+            );
+            assert_eq!(
+                UdsServiceType::from_response_sid(response_sid),
+                service,
+                "response SID {response_sid:#04X}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_response_sid_is_the_request_sid_with_bit_6_set() {
+        // ISO 14229-1 derives every positive response SID by adding 0x40 to the request SID.
+        // Checking the rule as well as the table catches a single mistyped entry above, which a
+        // table compared only against itself would not.
+        for &(service, request_sid, response_sid) in SERVICES {
+            assert_eq!(
+                response_sid,
+                request_sid + 0x40,
+                "{service:?} breaks the +0x40 rule"
+            );
+        }
+    }
+
+    #[test]
+    fn the_two_services_without_a_request_sid_say_so() {
+        // Both have no request SID and return 0x7F, which is not a legal request SID -- it is the
+        // negative-response SID. Callers needing lossless round-tripping of an unmodeled service
+        // must use `Request::Other`, so this is pinned rather than left to be discovered.
+        assert_eq!(
+            UdsServiceType::to_request_sid(UdsServiceType::NegativeResponse),
+            0x7F
+        );
+        assert_eq!(
+            UdsServiceType::to_request_sid(UdsServiceType::UnsupportedDiagnosticService),
+            0x7F
+        );
+        assert_eq!(
+            UdsServiceType::from_response_sid(0x7F),
+            UdsServiceType::NegativeResponse
+        );
+    }
+
+    #[test]
+    fn every_unassigned_byte_classifies_as_unsupported() {
+        // The conversions are total: no byte panics, and anything outside the table above lands
+        // on `UnsupportedDiagnosticService` rather than being silently mapped to a real service.
+        // Written with `any` rather than collecting, so this compiles without `alloc`.
+        let is_request_sid = |b: u8| SERVICES.iter().any(|&(_, r, _)| r == b);
+        let is_response_sid = |b: u8| b == 0x7F || SERVICES.iter().any(|&(_, _, s)| s == b);
+
+        for byte in 0x00..=0xFFu8 {
+            let from_request = UdsServiceType::from_request_sid(byte);
+            if is_request_sid(byte) {
+                assert_ne!(
+                    from_request,
+                    UdsServiceType::UnsupportedDiagnosticService,
+                    "{byte:#04X} is an assigned request SID"
+                );
+            } else {
+                assert_eq!(
+                    from_request,
+                    UdsServiceType::UnsupportedDiagnosticService,
+                    "{byte:#04X} is unassigned and must not map to a service"
+                );
+            }
+
+            let from_response = UdsServiceType::from_response_sid(byte);
+            if !is_response_sid(byte) {
+                assert_eq!(
+                    from_response,
+                    UdsServiceType::UnsupportedDiagnosticService,
+                    "{byte:#04X} is unassigned and must not map to a service"
+                );
+            }
+        }
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -56,7 +56,7 @@ pub enum UdsServiceType {
     /// Enable or disable the detection of any or all errors.
     /// This is important when diagnostic work is performed in the car,
     /// which can cause an anomalous behavior of individual devices.
-    ControlDTCSettings,
+    ControlDtcSetting,
     /// Request the server to start or stop sending responses when a specified event occurs.
     ResponseOnEvent,
     /// The Service Link Control is used to set the baud rate of the diagnostic access.
@@ -98,7 +98,7 @@ pub enum UdsServiceType {
     /// These DTCs can be read via this service.
     ///  In addition to the errors themselves,
     /// additional diagnostic information is stored.
-    ReadDTCInfo,
+    ReadDtcInfo,
     // ========================================================================
     // Input / Output Control
     /// Substitute or control an input/output signal using a DID.
@@ -155,7 +155,7 @@ impl UdsServiceType {
             0x3E => Self::TesterPresent,
             0x83 => Self::AccessTimingParameters,
             0x84 => Self::SecuredDataTransmission,
-            0x85 => Self::ControlDTCSettings,
+            0x85 => Self::ControlDtcSetting,
             0x86 => Self::ResponseOnEvent,
             0x87 => Self::LinkControl,
             0x22 => Self::ReadDataByIdentifier,
@@ -166,7 +166,7 @@ impl UdsServiceType {
             0x2E => Self::WriteDataByIdentifier,
             0x3D => Self::WriteMemoryByAddress,
             0x14 => Self::ClearDiagnosticInfo,
-            0x19 => Self::ReadDTCInfo,
+            0x19 => Self::ReadDtcInfo,
             0x2F => Self::InputOutputControlByIdentifier,
             0x31 => Self::RoutineControl,
             0x34 => Self::RequestDownload,
@@ -197,7 +197,7 @@ impl UdsServiceType {
             Self::TesterPresent => 0x3E,
             Self::AccessTimingParameters => 0x83,
             Self::SecuredDataTransmission => 0x84,
-            Self::ControlDTCSettings => 0x85,
+            Self::ControlDtcSetting => 0x85,
             Self::ResponseOnEvent => 0x86,
             Self::LinkControl => 0x87,
             Self::ReadDataByIdentifier => 0x22,
@@ -208,7 +208,7 @@ impl UdsServiceType {
             Self::WriteDataByIdentifier => 0x2E,
             Self::WriteMemoryByAddress => 0x3D,
             Self::ClearDiagnosticInfo => 0x14,
-            Self::ReadDTCInfo => 0x19,
+            Self::ReadDtcInfo => 0x19,
             Self::InputOutputControlByIdentifier => 0x2F,
             Self::RoutineControl => 0x31,
             Self::RequestDownload => 0x34,
@@ -233,7 +233,7 @@ impl UdsServiceType {
             0x7E => Self::TesterPresent,
             0xC3 => Self::AccessTimingParameters,
             0xC4 => Self::SecuredDataTransmission,
-            0xC5 => Self::ControlDTCSettings,
+            0xC5 => Self::ControlDtcSetting,
             0xC6 => Self::ResponseOnEvent,
             0xC7 => Self::LinkControl,
             0x62 => Self::ReadDataByIdentifier,
@@ -244,7 +244,7 @@ impl UdsServiceType {
             0x6E => Self::WriteDataByIdentifier,
             0x7D => Self::WriteMemoryByAddress,
             0x54 => Self::ClearDiagnosticInfo,
-            0x59 => Self::ReadDTCInfo,
+            0x59 => Self::ReadDtcInfo,
             0x6F => Self::InputOutputControlByIdentifier,
             0x71 => Self::RoutineControl,
             0x74 => Self::RequestDownload,
@@ -272,7 +272,7 @@ impl UdsServiceType {
             Self::TesterPresent => 0x7E,
             Self::AccessTimingParameters => 0xC3,
             Self::SecuredDataTransmission => 0xC4,
-            Self::ControlDTCSettings => 0xC5,
+            Self::ControlDtcSetting => 0xC5,
             Self::ResponseOnEvent => 0xC6,
             Self::LinkControl => 0xC7,
             Self::ReadDataByIdentifier => 0x62,
@@ -283,7 +283,7 @@ impl UdsServiceType {
             Self::WriteDataByIdentifier => 0x6E,
             Self::WriteMemoryByAddress => 0x7D,
             Self::ClearDiagnosticInfo => 0x54,
-            Self::ReadDTCInfo => 0x59,
+            Self::ReadDtcInfo => 0x59,
             Self::InputOutputControlByIdentifier => 0x6F,
             Self::RoutineControl => 0x71,
             Self::RequestDownload => 0x74,

--- a/src/services/clear_dtc_information.rs
+++ b/src/services/clear_dtc_information.rs
@@ -1,5 +1,5 @@
 //! `ClearDiagnosticInformation` (0x14) service implementation
-use crate::{CLEAR_ALL_DTCS, DTCRecord, Decode, Encode, Incomplete, NegativeResponseCode};
+use crate::{CLEAR_ALL_DTCS, Decode, DtcRecord, Encode, Incomplete, NegativeResponseCode};
 use automotive_wire_codec::write_u8;
 
 /// Positive response to `ClearDiagnosticInformation`. Carries no payload.
@@ -49,7 +49,7 @@ const CLEAR_DIAG_INFO_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] = [
 #[non_exhaustive]
 pub struct ClearDiagnosticInfoRequest {
     /// Can be either a DTC group (such as chassis/powertrain) or a single DTC
-    pub group_of_dtc: DTCRecord,
+    pub group_of_dtc: DtcRecord,
     /// Used to address a specific memory location of user-defined DTC memory
     pub memory_selection: u8,
 }
@@ -57,7 +57,7 @@ pub struct ClearDiagnosticInfoRequest {
 impl ClearDiagnosticInfoRequest {
     /// Create a request to clear a specific DTC group from the given memory location.
     #[must_use]
-    pub const fn new(group_of_dtc: DTCRecord, memory_selection: u8) -> Self {
+    pub const fn new(group_of_dtc: DtcRecord, memory_selection: u8) -> Self {
         Self {
             group_of_dtc,
             memory_selection,
@@ -94,7 +94,7 @@ impl<'a> Decode<'a> for ClearDiagnosticInfoRequest {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), crate::Error> {
-        let (group_of_dtc, buf) = <DTCRecord as Decode>::decode(buf)?;
+        let (group_of_dtc, buf) = <DtcRecord as Decode>::decode(buf)?;
         if buf.is_empty() {
             return Err(crate::Error::InsufficientData(Incomplete {
                 needed: 4,

--- a/src/services/communication_control.rs
+++ b/src/services/communication_control.rs
@@ -41,7 +41,7 @@ pub enum CommunicationControlType {
     /// range-checked and can never collide with the SPRMIB bit.
     #[cfg_attr(feature = "clap", clap(skip))]
     #[non_exhaustive]
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
     /// Values reserved for use by vehicle manufacturers.
     ///
     /// Construct through [`CommunicationControlType::try_from`] so the raw byte is
@@ -80,7 +80,7 @@ impl From<CommunicationControlType> for u8 {
             CommunicationControlType::DisableRxAndTx => 0x03,
             CommunicationControlType::EnableRxAndDisableTxWithEnhancedAddressInfo => 0x04,
             CommunicationControlType::EnableRxAndTxWithEnhancedAddressInfo => 0x05,
-            CommunicationControlType::ISOSAEReserved(val) => val,
+            CommunicationControlType::IsoSaeReserved(val) => val,
             CommunicationControlType::VehicleManufacturerSpecific(val) => val,
             CommunicationControlType::SystemSupplierSpecific(val) => val,
         }
@@ -97,7 +97,7 @@ impl TryFrom<u8> for CommunicationControlType {
             0x03 => Ok(Self::DisableRxAndTx),
             0x04 => Ok(Self::EnableRxAndDisableTxWithEnhancedAddressInfo),
             0x05 => Ok(Self::EnableRxAndTxWithEnhancedAddressInfo),
-            0x06..=0x3F | 0x7F => Ok(Self::ISOSAEReserved(value)),
+            0x06..=0x3F | 0x7F => Ok(Self::IsoSaeReserved(value)),
             0x40..=0x5F => Ok(Self::VehicleManufacturerSpecific(value)),
             0x60..=0x7E => Ok(Self::SystemSupplierSpecific(value)),
             _ => Err(Error::InvalidCommunicationControlType(value)),
@@ -141,7 +141,7 @@ mod communication_control_type_tests {
                 0x06..=0x3F | 0x7F => {
                     assert!(matches!(
                         msg_type,
-                        Ok(CommunicationControlType::ISOSAEReserved(_))
+                        Ok(CommunicationControlType::IsoSaeReserved(_))
                     ));
                 }
                 0x40..=0x5F => {
@@ -192,7 +192,7 @@ mod communication_control_type_tests {
 #[non_exhaustive]
 pub enum CommunicationType {
     /// This value is reserved by the ISO 14229-1 Specification
-    ISOSAEReserved,
+    IsoSaeReserved,
     /// This value represents all application related communication.
     Normal,
     /// This value represents all network management related communication.
@@ -204,7 +204,7 @@ pub enum CommunicationType {
 impl From<CommunicationType> for u8 {
     fn from(value: CommunicationType) -> Self {
         match value {
-            CommunicationType::ISOSAEReserved => 0x00,
+            CommunicationType::IsoSaeReserved => 0x00,
             CommunicationType::Normal => 0x01,
             CommunicationType::NetworkManagement => 0x02,
             CommunicationType::NormalAndNetworkManagement => 0x03,
@@ -216,7 +216,7 @@ impl TryFrom<u8> for CommunicationType {
     type Error = Error;
     fn try_from(value: u8) -> Result<Self, Error> {
         match value {
-            0x00 => Ok(Self::ISOSAEReserved),
+            0x00 => Ok(Self::IsoSaeReserved),
             0x01 => Ok(Self::Normal),
             0x02 => Ok(CommunicationType::NetworkManagement),
             0x03 => Ok(CommunicationType::NormalAndNetworkManagement),
@@ -234,7 +234,7 @@ mod communication_type_tests {
         for i in 0..=u8::MAX {
             let msg_type = CommunicationType::try_from(i);
             match i {
-                0x00 => assert!(matches!(msg_type, Ok(CommunicationType::ISOSAEReserved))),
+                0x00 => assert!(matches!(msg_type, Ok(CommunicationType::IsoSaeReserved))),
                 0x01 => assert!(matches!(msg_type, Ok(CommunicationType::Normal))),
                 0x02 => assert!(matches!(msg_type, Ok(CommunicationType::NetworkManagement))),
                 0x03 => assert!(matches!(

--- a/src/services/control_dtc_settings.rs
+++ b/src/services/control_dtc_settings.rs
@@ -10,24 +10,24 @@ use automotive_wire_codec::write_u8;
 #[non_exhaustive]
 /// Controls whether the server should enable or disable DTC status-bit updates.
 ///
-/// Used by [`ControlDTCSettingsRequest`] to instruct the server.
-pub enum DtcSettings {
+/// Used by [`ControlDtcSettingRequest`] to instruct the server.
+pub enum DtcSettingType {
     /// Re-enable DTC status-bit updates.
     On,
     /// Disable DTC status-bit updates.
     Off,
 }
 
-impl From<DtcSettings> for u8 {
-    fn from(value: DtcSettings) -> Self {
+impl From<DtcSettingType> for u8 {
+    fn from(value: DtcSettingType) -> Self {
         match value {
-            DtcSettings::On => 0x01,
-            DtcSettings::Off => 0x02,
+            DtcSettingType::On => 0x01,
+            DtcSettingType::Off => 0x02,
         }
     }
 }
 
-impl TryFrom<u8> for DtcSettings {
+impl TryFrom<u8> for DtcSettingType {
     type Error = Error;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
@@ -38,29 +38,29 @@ impl TryFrom<u8> for DtcSettings {
     }
 }
 
-/// The `ControlDTCSettings` service is used to control the DTC settings of the ECU.
+/// The `ControlDtcSetting` service is used to control the DTC settings of the ECU.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub struct ControlDTCSettingsRequest {
+pub struct ControlDtcSettingRequest {
     /// Whether the server should suppress the positive response (SPRMIB).
     pub suppress_positive_response: bool,
     /// The requested DTC logging setting.
-    pub setting: DtcSettings,
+    pub setting: DtcSettingType,
 }
 
-const CONTROL_DTC_SETTINGS_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] = [
+const CONTROL_DTC_SETTING_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] = [
     NegativeResponseCode::SubFunctionNotSupported,
     NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
     NegativeResponseCode::ConditionsNotCorrect,
     NegativeResponseCode::RequestOutOfRange,
 ];
 
-impl ControlDTCSettingsRequest {
-    /// Create a new `ControlDTCSettingsRequest`.
+impl ControlDtcSettingRequest {
+    /// Create a new `ControlDtcSettingRequest`.
     #[must_use]
-    pub const fn new(suppress_positive_response: bool, setting: DtcSettings) -> Self {
+    pub const fn new(suppress_positive_response: bool, setting: DtcSettingType) -> Self {
         Self {
             suppress_positive_response,
             setting,
@@ -70,11 +70,11 @@ impl ControlDTCSettingsRequest {
     /// Get the allowed [`NegativeResponseCode`] variants for this request.
     #[must_use]
     pub fn allowed_nack_codes() -> &'static [NegativeResponseCode] {
-        &CONTROL_DTC_SETTINGS_NEGATIVE_RESPONSE_CODES
+        &CONTROL_DTC_SETTING_NEGATIVE_RESPONSE_CODES
     }
 }
 
-impl Encode for ControlDTCSettingsRequest {
+impl Encode for ControlDtcSettingRequest {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
@@ -84,7 +84,7 @@ impl Encode for ControlDTCSettingsRequest {
     }
 }
 
-impl<'a> Decode<'a> for ControlDTCSettingsRequest {
+impl<'a> Decode<'a> for ControlDtcSettingRequest {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
@@ -94,7 +94,7 @@ impl<'a> Decode<'a> for ControlDTCSettingsRequest {
                 available: buf.len(),
             }));
         }
-        let sub_function = SuppressablePositiveResponse::<DtcSettings>::try_from(buf[0])?;
+        let sub_function = SuppressablePositiveResponse::<DtcSettingType>::try_from(buf[0])?;
         Ok((
             Self {
                 suppress_positive_response: sub_function.suppress_positive_response(),
@@ -105,27 +105,27 @@ impl<'a> Decode<'a> for ControlDTCSettingsRequest {
     }
 }
 
-/// Positive response to a `ControlDTCSettingsRequest`
+/// Positive response to a `ControlDtcSettingRequest`
 ///
-/// The ECU will respond with a `ControlDTCSettingsResponse` if the request was successful.
+/// The ECU will respond with a `ControlDtcSettingResponse` if the request was successful.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub struct ControlDTCSettingsResponse {
+pub struct ControlDtcSettingResponse {
     /// The DTC logging setting that was set in the request
-    pub setting: DtcSettings,
+    pub setting: DtcSettingType,
 }
 
-impl ControlDTCSettingsResponse {
-    /// Create a new `ControlDTCSettingsResponse`.
+impl ControlDtcSettingResponse {
+    /// Create a new `ControlDtcSettingResponse`.
     #[must_use]
-    pub const fn new(setting: DtcSettings) -> Self {
+    pub const fn new(setting: DtcSettingType) -> Self {
         Self { setting }
     }
 }
 
-impl Encode for ControlDTCSettingsResponse {
+impl Encode for ControlDtcSettingResponse {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
@@ -133,7 +133,7 @@ impl Encode for ControlDTCSettingsResponse {
     }
 }
 
-impl<'a> Decode<'a> for ControlDTCSettingsResponse {
+impl<'a> Decode<'a> for ControlDtcSettingResponse {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
@@ -143,7 +143,7 @@ impl<'a> Decode<'a> for ControlDTCSettingsResponse {
                 available: buf.len(),
             }));
         }
-        let setting = DtcSettings::try_from(buf[0])?;
+        let setting = DtcSettingType::try_from(buf[0])?;
         Ok((Self { setting }, &buf[1..]))
     }
 }
@@ -158,15 +158,15 @@ mod request {
     #[cfg(feature = "alloc")]
     #[test]
     fn simple_request() {
-        let req = ControlDTCSettingsRequest::new(true, DtcSettings::On);
+        let req = ControlDtcSettingRequest::new(true, DtcSettingType::On);
         let mut buffer = Vec::new();
         let written = Encode::encode(&req, &mut buffer).unwrap();
         assert_eq!(buffer, vec![0x81]);
         assert_eq!(written, buffer.len());
         assert_eq!(req.encoded_size().unwrap(), buffer.len());
 
-        let (parsed, _) = <ControlDTCSettingsRequest as Decode>::decode(&buffer).unwrap();
-        assert_eq!(parsed.setting, DtcSettings::On);
+        let (parsed, _) = <ControlDtcSettingRequest as Decode>::decode(&buffer).unwrap();
+        assert_eq!(parsed.setting, DtcSettingType::On);
         assert!(parsed.suppress_positive_response);
         assert_encode_size_agrees(&req);
     }
@@ -175,15 +175,15 @@ mod request {
     fn invalid_setting_byte_carries_the_value() {
         // An unrecognized setting must surface the offending byte, like every other
         // service's Invalid<Service>Type error, not the generic length/format error.
-        let err = <ControlDTCSettingsRequest as Decode>::decode(&[0x09]).unwrap_err();
+        let err = <ControlDtcSettingRequest as Decode>::decode(&[0x09]).unwrap_err();
         assert!(matches!(err, Error::InvalidDtcSetting(0x09)));
     }
 
     #[test]
     fn exposes_allowed_nack_codes() {
-        assert!(!ControlDTCSettingsRequest::allowed_nack_codes().is_empty());
+        assert!(!ControlDtcSettingRequest::allowed_nack_codes().is_empty());
         assert!(
-            ControlDTCSettingsRequest::allowed_nack_codes()
+            ControlDtcSettingRequest::allowed_nack_codes()
                 .contains(&NegativeResponseCode::RequestOutOfRange)
         );
     }
@@ -199,20 +199,20 @@ mod response {
     #[cfg(feature = "alloc")]
     #[test]
     fn simple_response() {
-        let req = ControlDTCSettingsResponse::new(DtcSettings::On);
+        let req = ControlDtcSettingResponse::new(DtcSettingType::On);
         let mut buffer = Vec::new();
         let written = Encode::encode(&req, &mut buffer).unwrap();
         assert_eq!(buffer, vec![0x01]);
         assert_eq!(written, buffer.len());
         assert_eq!(req.encoded_size().unwrap(), buffer.len());
 
-        let (parsed, _) = <ControlDTCSettingsResponse as Decode>::decode(&buffer).unwrap();
-        assert_eq!(parsed.setting, DtcSettings::On);
+        let (parsed, _) = <ControlDtcSettingResponse as Decode>::decode(&buffer).unwrap();
+        assert_eq!(parsed.setting, DtcSettingType::On);
         assert_encode_size_agrees(&req);
     }
 
     #[test]
     fn response_is_eq() {
-        crate::test_util::assert_impl_eq::<ControlDTCSettingsResponse>();
+        crate::test_util::assert_impl_eq::<ControlDtcSettingResponse>();
     }
 }

--- a/src/services/diagnostic_session_control.rs
+++ b/src/services/diagnostic_session_control.rs
@@ -30,7 +30,7 @@ pub enum DiagnosticSessionType {
     /// Construct through [`DiagnosticSessionType::try_from`] so the raw byte is range-checked and can never collide with the SPRMIB bit.
     #[cfg_attr(feature = "clap", clap(skip))]
     #[non_exhaustive]
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
     /// The `DefaultSession` (0x01) enables the standard diagnostic functionality
     /// - No `TesterPresent` messages are required to remain in this session
     /// - Any other diagnostic sessions are stopped upon successful entry into this session
@@ -63,7 +63,7 @@ impl From<DiagnosticSessionType> for u8 {
     #[allow(clippy::match_same_arms)]
     fn from(value: DiagnosticSessionType) -> Self {
         match value {
-            DiagnosticSessionType::ISOSAEReserved(value) => value,
+            DiagnosticSessionType::IsoSaeReserved(value) => value,
             DiagnosticSessionType::DefaultSession => 0x01,
             DiagnosticSessionType::ProgrammingSession => 0x02,
             DiagnosticSessionType::ExtendedDiagnosticSession => 0x03,
@@ -79,17 +79,17 @@ impl TryFrom<u8> for DiagnosticSessionType {
     #[allow(clippy::match_same_arms)]
     fn try_from(value: u8) -> Result<Self, Error> {
         match value {
-            0x00 => Ok(DiagnosticSessionType::ISOSAEReserved(value)),
+            0x00 => Ok(DiagnosticSessionType::IsoSaeReserved(value)),
             0x01 => Ok(DiagnosticSessionType::DefaultSession),
             0x02 => Ok(DiagnosticSessionType::ProgrammingSession),
             0x03 => Ok(DiagnosticSessionType::ExtendedDiagnosticSession),
             0x04 => Ok(DiagnosticSessionType::SafetySystemDiagnosticSession),
-            0x05..=0x3F => Ok(DiagnosticSessionType::ISOSAEReserved(value)),
+            0x05..=0x3F => Ok(DiagnosticSessionType::IsoSaeReserved(value)),
             0x40..=0x5F => Ok(DiagnosticSessionType::VehicleManufacturerSpecificSession(
                 value,
             )),
             0x60..=0x7E => Ok(DiagnosticSessionType::SystemSupplierSpecificSession(value)),
-            0x7F => Ok(DiagnosticSessionType::ISOSAEReserved(value)),
+            0x7F => Ok(DiagnosticSessionType::IsoSaeReserved(value)),
             _ => Err(Error::InvalidDiagnosticSessionType(value)),
         }
     }
@@ -123,7 +123,7 @@ mod diagnostic_session_type_tests {
                 0x00 | 0x05..=0x3F | 0x7F => {
                     assert!(matches!(
                         msg_type,
-                        Ok(DiagnosticSessionType::ISOSAEReserved(_))
+                        Ok(DiagnosticSessionType::IsoSaeReserved(_))
                     ));
                 }
                 0x40..=0x5F => {

--- a/src/services/ecu_reset.rs
+++ b/src/services/ecu_reset.rs
@@ -22,7 +22,7 @@ pub enum ResetType {
     /// range-checked (`0x00..=0x7F`) and can never collide with the SPRMIB bit.
     #[cfg_attr(feature = "clap", clap(skip))]
     #[non_exhaustive]
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
     /// This `SubFunction` identifies a "hard reset" condition which simulates the power-on/start-up sequence
     /// typically performed after a server has been previously disconnected from its power supply (i.e. battery).
     /// The performed action is implementation specific and not defined by the spec.
@@ -74,7 +74,7 @@ impl From<ResetType> for u8 {
     #[allow(clippy::match_same_arms)]
     fn from(value: ResetType) -> Self {
         match value {
-            ResetType::ISOSAEReserved(val) => val,
+            ResetType::IsoSaeReserved(val) => val,
             ResetType::HardReset => 0x01,
             ResetType::KeyOffOnReset => 0x02,
             ResetType::SoftReset => 0x03,
@@ -91,16 +91,16 @@ impl TryFrom<u8> for ResetType {
     #[allow(clippy::match_same_arms)]
     fn try_from(value: u8) -> Result<Self, Error> {
         match value {
-            0x00 => Ok(Self::ISOSAEReserved(0)),
+            0x00 => Ok(Self::IsoSaeReserved(0)),
             0x01 => Ok(Self::HardReset),
             0x02 => Ok(Self::KeyOffOnReset),
             0x03 => Ok(Self::SoftReset),
             0x04 => Ok(Self::EnableRapidPowerShutDown),
             0x05 => Ok(Self::DisableRapidPowerShutDown),
-            0x06..=0x3F => Ok(Self::ISOSAEReserved(value)),
+            0x06..=0x3F => Ok(Self::IsoSaeReserved(value)),
             0x40..=0x5F => Ok(Self::VehicleManufacturerSpecific(value)),
             0x60..=0x7E => Ok(Self::SystemSupplierSpecific(value)),
-            0x7F => Ok(Self::ISOSAEReserved(value)),
+            0x7F => Ok(Self::IsoSaeReserved(value)),
             _ => Err(Error::InvalidEcuResetType(value)),
         }
     }
@@ -118,7 +118,7 @@ mod reset_type_tests {
             match i {
                 0x00 => assert!(matches!(
                     reset_type,
-                    Ok::<ResetType, Error>(ResetType::ISOSAEReserved(_)),
+                    Ok::<ResetType, Error>(ResetType::IsoSaeReserved(_)),
                 )),
                 0x01 => assert!(matches!(
                     reset_type,
@@ -142,7 +142,7 @@ mod reset_type_tests {
                 )),
                 0x06..=0x3F => assert!(matches!(
                     reset_type,
-                    Ok::<ResetType, Error>(ResetType::ISOSAEReserved(_)),
+                    Ok::<ResetType, Error>(ResetType::IsoSaeReserved(_)),
                 )),
                 0x40..=0x5F => assert!(matches!(
                     reset_type,
@@ -154,7 +154,7 @@ mod reset_type_tests {
                 )),
                 0x7F => assert!(matches!(
                     reset_type,
-                    Ok::<ResetType, Error>(ResetType::ISOSAEReserved(_)),
+                    Ok::<ResetType, Error>(ResetType::IsoSaeReserved(_)),
                 )),
                 _ => assert!(matches!(
                     reset_type,
@@ -166,7 +166,7 @@ mod reset_type_tests {
 
     #[test]
     fn reset_type_to_all_u8_values() {
-        assert_eq!(u8::from(ResetType::ISOSAEReserved(0)), 0x00);
+        assert_eq!(u8::from(ResetType::IsoSaeReserved(0)), 0x00);
         assert_eq!(u8::from(ResetType::HardReset), 0x01);
         assert_eq!(u8::from(ResetType::KeyOffOnReset), 0x02);
         assert_eq!(u8::from(ResetType::SoftReset), 0x03);

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -9,7 +9,7 @@ pub use communication_control::{
 
 mod control_dtc_settings;
 pub use control_dtc_settings::{
-    ControlDTCSettingsRequest, ControlDTCSettingsResponse, DtcSettings,
+    ControlDtcSettingRequest, ControlDtcSettingResponse, DtcSettingType,
 };
 
 mod diagnostic_session_control;
@@ -28,8 +28,8 @@ pub use read_data_by_identifier::{ReadDataByIdentifierRequest, ReadDataByIdentif
 
 mod read_dtc_information;
 pub use read_dtc_information::{
-    DTCFaultDetectionCounterRecord, DtcAndStatusIter, DtcFaultDetectionIter,
-    DtcSeverityAndStatusIter, ReadDTCInfoRequest, ReadDTCInfoResponse, ReadDTCInfoSubFunction,
+    DtcAndStatusIter, DtcFaultDetectionCounterRecord, DtcFaultDetectionIter,
+    DtcSeverityAndStatusIter, ReadDtcInfoRequest, ReadDtcInfoResponse, ReadDtcInfoSubFunction,
 };
 
 mod request_download;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -28,8 +28,8 @@ pub use read_data_by_identifier::{ReadDataByIdentifierRequest, ReadDataByIdentif
 
 mod read_dtc_information;
 pub use read_dtc_information::{
-    DtcAndStatusIter, DtcFaultDetectionIter, DtcSeverityAndStatusIter, ReadDTCInfoRequest,
-    ReadDTCInfoResponse, ReadDTCInfoSubFunction,
+    DTCFaultDetectionCounterRecord, DtcAndStatusIter, DtcFaultDetectionIter,
+    DtcSeverityAndStatusIter, ReadDTCInfoRequest, ReadDTCInfoResponse, ReadDTCInfoSubFunction,
 };
 
 mod request_download;

--- a/src/services/negative_response.rs
+++ b/src/services/negative_response.rs
@@ -25,7 +25,7 @@ impl NegativeResponse {
     #[must_use]
     pub fn new(request_service: UdsServiceType, nrc: NegativeResponseCode) -> Self {
         Self {
-            request_service_sid: request_service.request_service_to_byte(),
+            request_service_sid: request_service.to_request_sid(),
             nrc,
         }
     }
@@ -37,7 +37,7 @@ impl NegativeResponse {
     /// from [`request_service_sid`](Self::request_service_sid) and is what gets re-encoded.
     #[must_use]
     pub fn request_service(&self) -> UdsServiceType {
-        UdsServiceType::service_from_request_byte(self.request_service_sid)
+        UdsServiceType::from_request_sid(self.request_service_sid)
     }
 
     /// The raw echoed request-service byte, exactly as received on the wire.
@@ -105,7 +105,7 @@ mod tests {
         assert_eq!(nr.request_service_sid(), 0x40);
         assert_eq!(
             nr.request_service(),
-            UdsServiceType::service_from_request_byte(0x40)
+            UdsServiceType::from_request_sid(0x40)
         );
         let mut buf = [0u8; 2];
         let n = Encode::encode(&nr, &mut buf.as_mut_slice()).unwrap();

--- a/src/services/negative_response.rs
+++ b/src/services/negative_response.rs
@@ -103,10 +103,7 @@ mod tests {
         let (nr, rest) = <NegativeResponse as Decode>::decode(&wire).unwrap();
         assert!(rest.is_empty());
         assert_eq!(nr.request_service_sid(), 0x40);
-        assert_eq!(
-            nr.request_service(),
-            UdsServiceType::from_request_sid(0x40)
-        );
+        assert_eq!(nr.request_service(), UdsServiceType::from_request_sid(0x40));
         let mut buf = [0u8; 2];
         let n = Encode::encode(&nr, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(&buf[..n], &wire);

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -3,8 +3,8 @@
 use automotive_wire_codec::{read_u8, write_all, write_u8, write_u16_be};
 
 use crate::{
-    DTCExtDataRecordNumber, DTCFormatIdentifier, DTCRecord, DTCSeverityMask,
-    DTCSnapshotRecordNumber, DTCStatusMask, DTCStoredDataRecordNumber, Decode, Encode, Error,
+    Decode, DtcExtDataRecordNumber, DtcFormatIdentifier, DtcRecord, DtcSeverityMask,
+    DtcSnapshotRecordNumber, DtcStatusMask, DtcStoredDataRecordNumber, Encode, Error,
     FunctionalGroupIdentifier, Incomplete, NegativeResponseCode,
 };
 
@@ -19,15 +19,15 @@ const READ_DTC_INFO_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 3] = [
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub struct ReadDTCInfoRequest {
+pub struct ReadDtcInfoRequest {
     /// The sub-function specifying what DTC information to report.
-    pub dtc_subfunction: ReadDTCInfoSubFunction,
+    pub dtc_subfunction: ReadDtcInfoSubFunction,
 }
 
-impl ReadDTCInfoRequest {
-    /// Create a new `ReadDTCInfoRequest`.
+impl ReadDtcInfoRequest {
+    /// Create a new `ReadDtcInfoRequest`.
     #[must_use]
-    pub const fn new(dtc_subfunction: ReadDTCInfoSubFunction) -> Self {
+    pub const fn new(dtc_subfunction: ReadDtcInfoSubFunction) -> Self {
         Self { dtc_subfunction }
     }
 
@@ -38,7 +38,7 @@ impl ReadDTCInfoRequest {
     }
 }
 
-impl Encode for ReadDTCInfoRequest {
+impl Encode for ReadDtcInfoRequest {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
@@ -46,12 +46,12 @@ impl Encode for ReadDTCInfoRequest {
     }
 }
 
-impl<'a> Decode<'a> for ReadDTCInfoRequest {
+impl<'a> Decode<'a> for ReadDtcInfoRequest {
     type Error = crate::Error;
 
     #[allow(clippy::too_many_lines)]
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
-        use ReadDTCInfoSubFunction as S;
+        use ReadDtcInfoSubFunction as S;
         if buf.is_empty() {
             return Err(Error::InsufficientData(Incomplete {
                 needed: 1,
@@ -62,100 +62,100 @@ impl<'a> Decode<'a> for ReadDTCInfoRequest {
         let rest = &buf[1..];
         let (dtc_subfunction, rest) = match sub {
             0x01 => {
-                let (m, r) = DTCStatusMask::decode(rest)?;
-                (S::ReportNumberOfDTC_ByStatusMask(m), r)
+                let (m, r) = DtcStatusMask::decode(rest)?;
+                (S::ReportNumberOfDtcByStatusMask(m), r)
             }
             0x02 => {
-                let (m, r) = DTCStatusMask::decode(rest)?;
-                (S::ReportDTC_ByStatusMask(m), r)
+                let (m, r) = DtcStatusMask::decode(rest)?;
+                (S::ReportDtcByStatusMask(m), r)
             }
-            0x03 => (S::ReportDTCSnapshotIdentification, rest),
+            0x03 => (S::ReportDtcSnapshotIdentification, rest),
             0x04 => {
-                let (rec, r) = DTCRecord::decode(rest)?;
-                let (n, r) = DTCSnapshotRecordNumber::decode(r)?;
-                (S::ReportDTCSnapshotRecord_ByDTCNumber(rec, n), r)
+                let (rec, r) = DtcRecord::decode(rest)?;
+                let (n, r) = DtcSnapshotRecordNumber::decode(r)?;
+                (S::ReportDtcSnapshotRecordByDtcNumber(rec, n), r)
             }
             0x05 => {
-                let (n, r) = DTCStoredDataRecordNumber::decode(rest)?;
-                (S::ReportDTCStoredData_ByRecordNumber(n), r)
+                let (n, r) = DtcStoredDataRecordNumber::decode(rest)?;
+                (S::ReportDtcStoredDataByRecordNumber(n), r)
             }
             0x06 => {
-                let (rec, r) = DTCRecord::decode(rest)?;
-                let (n, r) = DTCExtDataRecordNumber::decode(r)?;
-                (S::ReportDTCExtDataRecord_ByDTCNumber(rec, n), r)
+                let (rec, r) = DtcRecord::decode(rest)?;
+                let (n, r) = DtcExtDataRecordNumber::decode(r)?;
+                (S::ReportDtcExtDataRecordByDtcNumber(rec, n), r)
             }
             0x07 => {
-                let (s, r) = DTCSeverityMask::decode(rest)?;
-                let (m, r) = DTCStatusMask::decode(r)?;
-                (S::ReportNumberOfDTC_BySeverityMaskRecord(s, m), r)
+                let (s, r) = DtcSeverityMask::decode(rest)?;
+                let (m, r) = DtcStatusMask::decode(r)?;
+                (S::ReportNumberOfDtcBySeverityMaskRecord(s, m), r)
             }
             0x08 => {
-                let (s, r) = DTCSeverityMask::decode(rest)?;
-                let (m, r) = DTCStatusMask::decode(r)?;
-                (S::ReportDTC_BySeverityMaskRecord(s, m), r)
+                let (s, r) = DtcSeverityMask::decode(rest)?;
+                let (m, r) = DtcStatusMask::decode(r)?;
+                (S::ReportDtcBySeverityMaskRecord(s, m), r)
             }
             0x09 => {
-                let (rec, r) = DTCRecord::decode(rest)?;
-                (S::ReportSeverityInfoOfDTC(rec), r)
+                let (rec, r) = DtcRecord::decode(rest)?;
+                (S::ReportSeverityInfoOfDtc(rec), r)
             }
-            0x0A => (S::ReportSupportedDTC, rest),
-            0x0B => (S::ReportFirstTestFailedDTC, rest),
-            0x0C => (S::ReportFirstConfirmedDTC, rest),
-            0x0D => (S::ReportMostRecentTestFailedDTC, rest),
-            0x0E => (S::ReportMostRecentConfirmedDTC, rest),
-            0x14 => (S::ReportDTCFaultDetectionCounter, rest),
-            0x15 => (S::ReportDTCWithPermanentStatus, rest),
+            0x0A => (S::ReportSupportedDtc, rest),
+            0x0B => (S::ReportFirstTestFailedDtc, rest),
+            0x0C => (S::ReportFirstConfirmedDtc, rest),
+            0x0D => (S::ReportMostRecentTestFailedDtc, rest),
+            0x0E => (S::ReportMostRecentConfirmedDtc, rest),
+            0x14 => (S::ReportDtcFaultDetectionCounter, rest),
+            0x15 => (S::ReportDtcWithPermanentStatus, rest),
             0x16 => {
-                let (n, r) = DTCExtDataRecordNumber::decode(rest)?;
-                (S::ReportDTCExtDataRecord_ByRecordNumber(n), r)
+                let (n, r) = DtcExtDataRecordNumber::decode(rest)?;
+                (S::ReportDtcExtDataRecordByRecordNumber(n), r)
             }
             0x17 => {
-                let (m, r) = DTCStatusMask::decode(rest)?;
-                (S::ReportUserDefMemoryDTC_ByStatusMask(m), r)
+                let (m, r) = DtcStatusMask::decode(rest)?;
+                (S::ReportUserDefMemoryDtcByStatusMask(m), r)
             }
             0x18 => {
-                let (rec, r) = DTCRecord::decode(rest)?;
-                let (n, r) = DTCSnapshotRecordNumber::decode(r)?;
+                let (rec, r) = DtcRecord::decode(rest)?;
+                let (n, r) = DtcSnapshotRecordNumber::decode(r)?;
                 let (mem, r) = read_u8(r)?;
                 (
-                    S::ReportUserDefMemoryDTCSnapshotRecord_ByDTCNumber(rec, n, mem),
+                    S::ReportUserDefMemoryDtcSnapshotRecordByDtcNumber(rec, n, mem),
                     r,
                 )
             }
             0x19 => {
-                let (rec, r) = DTCRecord::decode(rest)?;
-                let (n, r) = DTCExtDataRecordNumber::decode(r)?;
+                let (rec, r) = DtcRecord::decode(rest)?;
+                let (n, r) = DtcExtDataRecordNumber::decode(r)?;
                 let (mem, r) = read_u8(r)?;
                 (
-                    S::ReportUserDefMemoryDTCExtDataRecord_ByDTCNumber(rec, n, mem),
+                    S::ReportUserDefMemoryDtcExtDataRecordByDtcNumber(rec, n, mem),
                     r,
                 )
             }
             0x1A => {
-                let (n, r) = DTCExtDataRecordNumber::decode(rest)?;
-                (S::ReportSupportedDTCExtDataRecord(n), r)
+                let (n, r) = DtcExtDataRecordNumber::decode(rest)?;
+                (S::ReportSupportedDtcExtDataRecord(n), r)
             }
             0x42 => {
                 let (g, r) = FunctionalGroupIdentifier::decode(rest)?;
-                let (m, r) = DTCStatusMask::decode(r)?;
-                let (s, r) = DTCSeverityMask::decode(r)?;
-                (S::ReportWWHOBDDTC_ByMaskRecord(g, m, s), r)
+                let (m, r) = DtcStatusMask::decode(r)?;
+                let (s, r) = DtcSeverityMask::decode(r)?;
+                (S::ReportWwhObdDtcByMaskRecord(g, m, s), r)
             }
             0x55 => {
                 let (g, r) = FunctionalGroupIdentifier::decode(rest)?;
-                (S::ReportWWHOBDDTC_WithPermanentStatus(g), r)
+                (S::ReportWwhObdDtcWithPermanentStatus(g), r)
             }
             0x56 => {
                 let (g, r) = FunctionalGroupIdentifier::decode(rest)?;
                 let (rg, r) = read_u8(r)?;
                 (
-                    S::ReportDTCInformation_ByDTCReadinessGroupIdentifier(g, rg),
+                    S::ReportDtcInformationByDtcReadinessGroupIdentifier(g, rg),
                     r,
                 )
             }
-            other => (S::ISOSAEReserved(other), rest),
+            other => (S::IsoSaeReserved(other), rest),
         };
-        Ok((ReadDTCInfoRequest::new(dtc_subfunction), rest))
+        Ok((ReadDtcInfoRequest::new(dtc_subfunction), rest))
     }
 }
 
@@ -166,8 +166,8 @@ mod read_dtc_info_request_encode_tests {
 
     #[test]
     fn encode_no_param_subfunction() {
-        // 0x0A ReportSupportedDTC, no parameters.
-        let req = ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ReportSupportedDTC);
+        // 0x0A ReportSupportedDtc, no parameters.
+        let req = ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::ReportSupportedDtc);
         let mut buf = [0u8; 8];
         let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(&buf[..written], &[0x0A]);
@@ -176,9 +176,9 @@ mod read_dtc_info_request_encode_tests {
 
     #[test]
     fn encode_single_param_subfunction() {
-        // 0x02 ReportDTC_ByStatusMask(mask). DTCStatusMask is 1 byte.
-        let mask = DTCStatusMask::from(0xFF);
-        let req = ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ReportDTC_ByStatusMask(mask));
+        // 0x02 ReportDtcByStatusMask(mask). DtcStatusMask is 1 byte.
+        let mask = DtcStatusMask::from(0xFF);
+        let req = ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::ReportDtcByStatusMask(mask));
         let mut buf = [0u8; 8];
         let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(&buf[..written], &[0x02, 0xFF]);
@@ -187,11 +187,11 @@ mod read_dtc_info_request_encode_tests {
 
     #[test]
     fn encode_multi_param_subfunction() {
-        // 0x42 ReportWWHOBDDTC_ByMaskRecord(group, status, severity).
-        let req = ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ReportWWHOBDDTC_ByMaskRecord(
+        // 0x42 ReportWwhObdDtcByMaskRecord(group, status, severity).
+        let req = ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::ReportWwhObdDtcByMaskRecord(
             FunctionalGroupIdentifier::EmissionsSystemGroup,
-            DTCStatusMask::from(0x08),
-            DTCSeverityMask::CheckImmediately,
+            DtcStatusMask::from(0x08),
+            DtcSeverityMask::CheckImmediately,
         ));
         let mut buf = [0u8; 8];
         let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
@@ -201,8 +201,8 @@ mod read_dtc_info_request_encode_tests {
 
     #[test]
     fn encode_reserved_subfunction() {
-        // ISOSAEReserved carries the sub-function byte itself, no params.
-        let req = ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ISOSAEReserved(0x57));
+        // IsoSaeReserved carries the sub-function byte itself, no params.
+        let req = ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::IsoSaeReserved(0x57));
         let mut buf = [0u8; 8];
         let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(&buf[..written], &[0x57]);
@@ -214,34 +214,34 @@ mod read_dtc_info_request_encode_tests {
         use crate::Decode;
         // Encode into a scratch buffer (oracle), then decode_exact and assert round-trip fidelity.
         let cases = [
-            ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ReportSupportedDTC),
-            ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ReportDTC_ByStatusMask(
-                DTCStatusMask::from(0xFF),
+            ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::ReportSupportedDtc),
+            ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::ReportDtcByStatusMask(
+                DtcStatusMask::from(0xFF),
             )),
-            ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ReportWWHOBDDTC_ByMaskRecord(
+            ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::ReportWwhObdDtcByMaskRecord(
                 FunctionalGroupIdentifier::EmissionsSystemGroup,
-                DTCStatusMask::from(0x08),
-                DTCSeverityMask::CheckImmediately,
+                DtcStatusMask::from(0x08),
+                DtcSeverityMask::CheckImmediately,
             )),
-            ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ISOSAEReserved(0x57)),
-            ReadDTCInfoRequest::new(ReadDTCInfoSubFunction::ReportDTCSnapshotRecord_ByDTCNumber(
-                DTCRecord::new(0x12, 0x34, 0x56),
-                DTCSnapshotRecordNumber::new(0x01),
+            ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::IsoSaeReserved(0x57)),
+            ReadDtcInfoRequest::new(ReadDtcInfoSubFunction::ReportDtcSnapshotRecordByDtcNumber(
+                DtcRecord::new(0x12, 0x34, 0x56),
+                DtcSnapshotRecordNumber::new(0x01),
             )),
         ];
         for req in cases {
             let mut buf = [0u8; 16];
             let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
-            let decoded = <ReadDTCInfoRequest as Decode>::decode_exact(&buf[..written]).unwrap();
+            let decoded = <ReadDtcInfoRequest as Decode>::decode_exact(&buf[..written]).unwrap();
             assert_eq!(decoded, req);
         }
     }
 
     #[test]
     fn exposes_allowed_nack_codes() {
-        assert!(!ReadDTCInfoRequest::allowed_nack_codes().is_empty());
+        assert!(!ReadDtcInfoRequest::allowed_nack_codes().is_empty());
         assert!(
-            ReadDTCInfoRequest::allowed_nack_codes()
+            ReadDtcInfoRequest::allowed_nack_codes()
                 .contains(&NegativeResponseCode::RequestOutOfRange)
         );
     }
@@ -251,117 +251,116 @@ mod read_dtc_info_request_encode_tests {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DTCFaultDetectionCounterRecord {
+pub struct DtcFaultDetectionCounterRecord {
     /// The DTC this counter belongs to.
-    pub dtc_record: DTCRecord,
+    pub dtc_record: DtcRecord,
     /// Fault detection counter, used for non-emissions related servers.
     pub dtc_fault_detection_counter: u8,
 }
 
 /// Subfunctions for the `ReadDTCInformation` service
-#[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ReadDTCInfoSubFunction {
-    /// * Parameter: `DTCStatusMask`
+pub enum ReadDtcInfoSubFunction {
+    /// * Parameter: `DtcStatusMask`
     ///
     /// 0x01
-    ReportNumberOfDTC_ByStatusMask(DTCStatusMask),
-    /// * Parameter: `DTCStatusMask`
+    ReportNumberOfDtcByStatusMask(DtcStatusMask),
+    /// * Parameter: `DtcStatusMask`
     ///
     /// 0x02
-    ReportDTC_ByStatusMask(DTCStatusMask),
+    ReportDtcByStatusMask(DtcStatusMask),
 
     /// 0x03
-    ReportDTCSnapshotIdentification,
+    ReportDtcSnapshotIdentification,
 
-    /// Parameter: `DTCRecord` (3 bytes)
-    /// Parameter DTCSnapshotRecordNumber(1)
+    /// Parameter: `DtcRecord` (3 bytes)
+    /// Parameter DtcSnapshotRecordNumber(1)
     ///
     /// 0x04
-    ReportDTCSnapshotRecord_ByDTCNumber(DTCRecord, DTCSnapshotRecordNumber),
+    ReportDtcSnapshotRecordByDtcNumber(DtcRecord, DtcSnapshotRecordNumber),
 
-    /// * Parameter: DTCStoredDataRecordNumber(1)
+    /// * Parameter: DtcStoredDataRecordNumber(1)
     ///
     /// 0x05
-    ReportDTCStoredData_ByRecordNumber(DTCStoredDataRecordNumber),
+    ReportDtcStoredDataByRecordNumber(DtcStoredDataRecordNumber),
 
-    /// Parameter: `DTCRecord` (3 bytes)
-    /// Parameter: DTCExtDataRecordNumber(1)
+    /// Parameter: `DtcRecord` (3 bytes)
+    /// Parameter: DtcExtDataRecordNumber(1)
     ///
     /// 0x06
-    ReportDTCExtDataRecord_ByDTCNumber(DTCRecord, DTCExtDataRecordNumber),
+    ReportDtcExtDataRecordByDtcNumber(DtcRecord, DtcExtDataRecordNumber),
 
     /// * Parameter: DTCSeverityMaskRecord(2)
-    ///     * `DTCSeverityMask`
-    ///     * `DTCStatusMask`
+    ///     * `DtcSeverityMask`
+    ///     * `DtcStatusMask`
     ///
     /// 0x07
-    ReportNumberOfDTC_BySeverityMaskRecord(DTCSeverityMask, DTCStatusMask),
+    ReportNumberOfDtcBySeverityMaskRecord(DtcSeverityMask, DtcStatusMask),
     /// 0x08
-    ReportDTC_BySeverityMaskRecord(DTCSeverityMask, DTCStatusMask),
+    ReportDtcBySeverityMaskRecord(DtcSeverityMask, DtcStatusMask),
 
-    /// Parameter: `DTCRecord` (3 bytes)
+    /// Parameter: `DtcRecord` (3 bytes)
     ///
     /// 0x09
-    ReportSeverityInfoOfDTC(DTCRecord),
+    ReportSeverityInfoOfDtc(DtcRecord),
 
     /// 0x0A
-    ReportSupportedDTC,
+    ReportSupportedDtc,
     /// 0x0B
-    ReportFirstTestFailedDTC,
+    ReportFirstTestFailedDtc,
     /// 0x0C
-    ReportFirstConfirmedDTC,
+    ReportFirstConfirmedDtc,
     /// 0x0D
-    ReportMostRecentTestFailedDTC,
+    ReportMostRecentTestFailedDtc,
     /// 0x0E
-    ReportMostRecentConfirmedDTC,
+    ReportMostRecentConfirmedDtc,
     /// 0x14
-    ReportDTCFaultDetectionCounter,
+    ReportDtcFaultDetectionCounter,
     /// 0x15
-    ReportDTCWithPermanentStatus,
+    ReportDtcWithPermanentStatus,
 
-    /// * Parameter: DTCExtDataRecordNumber(1)
+    /// * Parameter: DtcExtDataRecordNumber(1)
     ///
     /// 0x16
-    ReportDTCExtDataRecord_ByRecordNumber(DTCExtDataRecordNumber),
+    ReportDtcExtDataRecordByRecordNumber(DtcExtDataRecordNumber),
 
-    /// * Parameter: `DTCStatusMask`
+    /// * Parameter: `DtcStatusMask`
     ///
     /// 0x17
-    ReportUserDefMemoryDTC_ByStatusMask(DTCStatusMask),
+    ReportUserDefMemoryDtcByStatusMask(DtcStatusMask),
 
-    /// Parameter: `DTCRecord` (3 bytes)
-    /// Parameter: `DTCSnapshotRecordNumber`(1)
+    /// Parameter: `DtcRecord` (3 bytes)
+    /// Parameter: `DtcSnapshotRecordNumber`(1)
     /// Parameter: `memorySelection`(1) — addresses the user-defined DTC memory to read from
     ///
     /// 0x18
-    ReportUserDefMemoryDTCSnapshotRecord_ByDTCNumber(DTCRecord, DTCSnapshotRecordNumber, u8),
+    ReportUserDefMemoryDtcSnapshotRecordByDtcNumber(DtcRecord, DtcSnapshotRecordNumber, u8),
 
-    /// Parameter: `DTCRecord` (3 bytes)
-    /// Parameter: `DTCExtDataRecordNumber`(1) (0xFF for all records)
+    /// Parameter: `DtcRecord` (3 bytes)
+    /// Parameter: `DtcExtDataRecordNumber`(1) (0xFF for all records)
     /// Parameter: `memorySelection`(1) — addresses the user-defined DTC memory to read from
     ///
     /// 0x19
-    ReportUserDefMemoryDTCExtDataRecord_ByDTCNumber(DTCRecord, DTCExtDataRecordNumber, u8),
+    ReportUserDefMemoryDtcExtDataRecordByDtcNumber(DtcRecord, DtcExtDataRecordNumber, u8),
 
-    /// * Parameter: DTCExtDataRecordNumber(1)
+    /// * Parameter: DtcExtDataRecordNumber(1)
     ///
     /// 0x1A
-    ReportSupportedDTCExtDataRecord(DTCExtDataRecordNumber),
+    ReportSupportedDtcExtDataRecord(DtcExtDataRecordNumber),
 
     /// * Parameter: FunctionalGroupIdentifier(1)
-    /// * Parameter: `DTCStatusMask`
-    /// * Parameter: `DTCSeverityMask`
+    /// * Parameter: `DtcStatusMask`
+    /// * Parameter: `DtcSeverityMask`
     ///
     /// 0x42
-    ReportWWHOBDDTC_ByMaskRecord(FunctionalGroupIdentifier, DTCStatusMask, DTCSeverityMask),
+    ReportWwhObdDtcByMaskRecord(FunctionalGroupIdentifier, DtcStatusMask, DtcSeverityMask),
 
     /// * Parameter: FunctionalGroupIdentifier(1)
     ///
     /// 0x55
-    ReportWWHOBDDTC_WithPermanentStatus(FunctionalGroupIdentifier),
+    ReportWwhObdDtcWithPermanentStatus(FunctionalGroupIdentifier),
 
     /// * Parameter: `FunctionalGroupIdentifier`(1)
     /// * Parameter: `DTCReadinessGroupIdentifier` (RGID, 1 byte). The RGID depends on the
@@ -369,111 +368,111 @@ pub enum ReadDTCInfoSubFunction {
     ///   [`FunctionalGroupIdentifier`].
     ///
     /// 0x56
-    ReportDTCInformation_ByDTCReadinessGroupIdentifier(FunctionalGroupIdentifier, u8),
+    ReportDtcInformationByDtcReadinessGroupIdentifier(FunctionalGroupIdentifier, u8),
     /// 0x42-0x54, 0x57-0x7F
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
 }
 
-impl ReadDTCInfoSubFunction {
+impl ReadDtcInfoSubFunction {
     /// Return the raw `u8` sub-function byte.
     #[must_use]
     pub const fn value(&self) -> u8 {
         match self {
-            Self::ReportNumberOfDTC_ByStatusMask(_) => 0x01,
-            Self::ReportDTC_ByStatusMask(_) => 0x02,
-            Self::ReportDTCSnapshotIdentification => 0x03,
-            Self::ReportDTCSnapshotRecord_ByDTCNumber(_, _) => 0x04,
-            Self::ReportDTCStoredData_ByRecordNumber(_) => 0x05,
-            Self::ReportDTCExtDataRecord_ByDTCNumber(_, _) => 0x06,
-            Self::ReportNumberOfDTC_BySeverityMaskRecord(_, _) => 0x07,
-            Self::ReportDTC_BySeverityMaskRecord(_, _) => 0x08,
-            Self::ReportSeverityInfoOfDTC(_) => 0x09,
-            Self::ReportSupportedDTC => 0x0A,
-            Self::ReportFirstTestFailedDTC => 0x0B,
-            Self::ReportFirstConfirmedDTC => 0x0C,
-            Self::ReportMostRecentTestFailedDTC => 0x0D,
-            Self::ReportMostRecentConfirmedDTC => 0x0E,
-            Self::ReportDTCFaultDetectionCounter => 0x14,
-            Self::ReportDTCWithPermanentStatus => 0x15,
-            Self::ReportDTCExtDataRecord_ByRecordNumber(_) => 0x16,
-            Self::ReportUserDefMemoryDTC_ByStatusMask(_) => 0x17,
-            Self::ReportUserDefMemoryDTCSnapshotRecord_ByDTCNumber(_, _, _) => 0x18,
-            Self::ReportUserDefMemoryDTCExtDataRecord_ByDTCNumber(_, _, _) => 0x19,
-            Self::ReportSupportedDTCExtDataRecord(_) => 0x1A,
-            Self::ReportWWHOBDDTC_ByMaskRecord(_, _, _) => 0x42,
-            Self::ReportWWHOBDDTC_WithPermanentStatus(_) => 0x55,
-            Self::ReportDTCInformation_ByDTCReadinessGroupIdentifier(_, _) => 0x56,
-            Self::ISOSAEReserved(value) => *value,
+            Self::ReportNumberOfDtcByStatusMask(_) => 0x01,
+            Self::ReportDtcByStatusMask(_) => 0x02,
+            Self::ReportDtcSnapshotIdentification => 0x03,
+            Self::ReportDtcSnapshotRecordByDtcNumber(_, _) => 0x04,
+            Self::ReportDtcStoredDataByRecordNumber(_) => 0x05,
+            Self::ReportDtcExtDataRecordByDtcNumber(_, _) => 0x06,
+            Self::ReportNumberOfDtcBySeverityMaskRecord(_, _) => 0x07,
+            Self::ReportDtcBySeverityMaskRecord(_, _) => 0x08,
+            Self::ReportSeverityInfoOfDtc(_) => 0x09,
+            Self::ReportSupportedDtc => 0x0A,
+            Self::ReportFirstTestFailedDtc => 0x0B,
+            Self::ReportFirstConfirmedDtc => 0x0C,
+            Self::ReportMostRecentTestFailedDtc => 0x0D,
+            Self::ReportMostRecentConfirmedDtc => 0x0E,
+            Self::ReportDtcFaultDetectionCounter => 0x14,
+            Self::ReportDtcWithPermanentStatus => 0x15,
+            Self::ReportDtcExtDataRecordByRecordNumber(_) => 0x16,
+            Self::ReportUserDefMemoryDtcByStatusMask(_) => 0x17,
+            Self::ReportUserDefMemoryDtcSnapshotRecordByDtcNumber(_, _, _) => 0x18,
+            Self::ReportUserDefMemoryDtcExtDataRecordByDtcNumber(_, _, _) => 0x19,
+            Self::ReportSupportedDtcExtDataRecord(_) => 0x1A,
+            Self::ReportWwhObdDtcByMaskRecord(_, _, _) => 0x42,
+            Self::ReportWwhObdDtcWithPermanentStatus(_) => 0x55,
+            Self::ReportDtcInformationByDtcReadinessGroupIdentifier(_, _) => 0x56,
+            Self::IsoSaeReserved(value) => *value,
         }
     }
 }
 
-impl Encode for ReadDTCInfoSubFunction {
+impl Encode for ReadDtcInfoSubFunction {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
-        use ReadDTCInfoSubFunction as S;
+        use ReadDtcInfoSubFunction as S;
         writer.write_all(&[self.value()]).map_err(Error::io)?;
         let mut written = 1;
         match self {
-            S::ReportNumberOfDTC_ByStatusMask(m)
-            | S::ReportDTC_ByStatusMask(m)
-            | S::ReportUserDefMemoryDTC_ByStatusMask(m) => {
+            S::ReportNumberOfDtcByStatusMask(m)
+            | S::ReportDtcByStatusMask(m)
+            | S::ReportUserDefMemoryDtcByStatusMask(m) => {
                 written += m.encode(writer)?;
             }
-            S::ReportDTCSnapshotRecord_ByDTCNumber(r, n) => {
+            S::ReportDtcSnapshotRecordByDtcNumber(r, n) => {
                 written += r.encode(writer)?;
                 written += n.encode(writer)?;
             }
-            S::ReportDTCStoredData_ByRecordNumber(n) => {
+            S::ReportDtcStoredDataByRecordNumber(n) => {
                 written += n.encode(writer)?;
             }
-            S::ReportDTCExtDataRecord_ByDTCNumber(r, n) => {
+            S::ReportDtcExtDataRecordByDtcNumber(r, n) => {
                 written += r.encode(writer)?;
                 written += n.encode(writer)?;
             }
-            S::ReportNumberOfDTC_BySeverityMaskRecord(s, m)
-            | S::ReportDTC_BySeverityMaskRecord(s, m) => {
+            S::ReportNumberOfDtcBySeverityMaskRecord(s, m)
+            | S::ReportDtcBySeverityMaskRecord(s, m) => {
                 written += s.encode(writer)?;
                 written += m.encode(writer)?;
             }
-            S::ReportSeverityInfoOfDTC(r) => {
+            S::ReportSeverityInfoOfDtc(r) => {
                 written += r.encode(writer)?;
             }
-            S::ReportDTCExtDataRecord_ByRecordNumber(n) | S::ReportSupportedDTCExtDataRecord(n) => {
+            S::ReportDtcExtDataRecordByRecordNumber(n) | S::ReportSupportedDtcExtDataRecord(n) => {
                 written += n.encode(writer)?;
             }
-            S::ReportUserDefMemoryDTCSnapshotRecord_ByDTCNumber(r, n, mem) => {
+            S::ReportUserDefMemoryDtcSnapshotRecordByDtcNumber(r, n, mem) => {
                 written += r.encode(writer)?;
                 written += n.encode(writer)?;
                 written += write_u8(writer, *mem).map_err(Error::io)?;
             }
-            S::ReportUserDefMemoryDTCExtDataRecord_ByDTCNumber(r, n, mem) => {
+            S::ReportUserDefMemoryDtcExtDataRecordByDtcNumber(r, n, mem) => {
                 written += r.encode(writer)?;
                 written += n.encode(writer)?;
                 written += write_u8(writer, *mem).map_err(Error::io)?;
             }
-            S::ReportWWHOBDDTC_ByMaskRecord(g, m, s) => {
+            S::ReportWwhObdDtcByMaskRecord(g, m, s) => {
                 written += g.encode(writer)?;
                 written += m.encode(writer)?;
                 written += s.encode(writer)?;
             }
-            S::ReportWWHOBDDTC_WithPermanentStatus(g) => {
+            S::ReportWwhObdDtcWithPermanentStatus(g) => {
                 written += g.encode(writer)?;
             }
-            S::ReportDTCInformation_ByDTCReadinessGroupIdentifier(g, rg) => {
+            S::ReportDtcInformationByDtcReadinessGroupIdentifier(g, rg) => {
                 written += g.encode(writer)?;
                 written += write_u8(writer, *rg).map_err(Error::io)?;
             }
-            S::ReportDTCSnapshotIdentification
-            | S::ReportSupportedDTC
-            | S::ReportFirstTestFailedDTC
-            | S::ReportFirstConfirmedDTC
-            | S::ReportMostRecentTestFailedDTC
-            | S::ReportMostRecentConfirmedDTC
-            | S::ReportDTCFaultDetectionCounter
-            | S::ReportDTCWithPermanentStatus
-            | S::ISOSAEReserved(_) => {}
+            S::ReportDtcSnapshotIdentification
+            | S::ReportSupportedDtc
+            | S::ReportFirstTestFailedDtc
+            | S::ReportFirstConfirmedDtc
+            | S::ReportMostRecentTestFailedDtc
+            | S::ReportMostRecentConfirmedDtc
+            | S::ReportDtcFaultDetectionCounter
+            | S::ReportDtcWithPermanentStatus
+            | S::IsoSaeReserved(_) => {}
         }
         Ok(written)
     }
@@ -483,7 +482,7 @@ impl Encode for ReadDTCInfoSubFunction {
 // no_std RX types with lazy iterators
 // ---------------------------------------------------------------------------
 
-/// Lazy iterator over `(DTCRecord, DTCStatusMask)` pairs from raw bytes.
+/// Lazy iterator over `(DtcRecord, DtcStatusMask)` pairs from raw bytes.
 ///
 /// Each pair is 4 bytes: 3 for the DTC record + 1 for the status mask.
 #[derive(Clone, Debug)]
@@ -492,7 +491,7 @@ pub struct DtcAndStatusIter<'a> {
 }
 
 impl<'a> DtcAndStatusIter<'a> {
-    /// Create an iterator over `(DTCRecord, DTCStatusMask)` pairs.
+    /// Create an iterator over `(DtcRecord, DtcStatusMask)` pairs.
     #[must_use]
     pub const fn new(data: &'a [u8]) -> Self {
         Self { remaining: data }
@@ -515,13 +514,13 @@ impl<'a> DtcAndStatusIter<'a> {
     /// # Errors
     /// Returns an error if the byte data contains a partial record.
     #[cfg(feature = "alloc")]
-    pub fn collect_all(self) -> Result<alloc::vec::Vec<(DTCRecord, DTCStatusMask)>, Error> {
+    pub fn collect_all(self) -> Result<alloc::vec::Vec<(DtcRecord, DtcStatusMask)>, Error> {
         self.collect()
     }
 }
 
 impl Iterator for DtcAndStatusIter<'_> {
-    type Item = Result<(DTCRecord, DTCStatusMask), Error>;
+    type Item = Result<(DtcRecord, DtcStatusMask), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining.is_empty() {
@@ -530,14 +529,14 @@ impl Iterator for DtcAndStatusIter<'_> {
         if self.remaining.len() < 4 {
             return Some(Err(Error::IncorrectMessageLengthOrInvalidFormat));
         }
-        let record = DTCRecord::new(self.remaining[0], self.remaining[1], self.remaining[2]);
-        let status = DTCStatusMask::from(self.remaining[3]);
+        let record = DtcRecord::new(self.remaining[0], self.remaining[1], self.remaining[2]);
+        let status = DtcStatusMask::from(self.remaining[3]);
         self.remaining = &self.remaining[4..];
         Some(Ok((record, status)))
     }
 }
 
-/// Lazy iterator over `DTCFaultDetectionCounterRecord` from raw bytes.
+/// Lazy iterator over `DtcFaultDetectionCounterRecord` from raw bytes.
 ///
 /// Each record is 4 bytes: 3 for the DTC record + 1 for the fault detection counter.
 #[derive(Clone, Debug)]
@@ -546,7 +545,7 @@ pub struct DtcFaultDetectionIter<'a> {
 }
 
 impl<'a> DtcFaultDetectionIter<'a> {
-    /// Create an iterator over `DTCFaultDetectionCounterRecord` values.
+    /// Create an iterator over `DtcFaultDetectionCounterRecord` values.
     #[must_use]
     pub const fn new(data: &'a [u8]) -> Self {
         Self { remaining: data }
@@ -569,13 +568,13 @@ impl<'a> DtcFaultDetectionIter<'a> {
     /// # Errors
     /// Returns an error if the byte data contains a partial record.
     #[cfg(feature = "alloc")]
-    pub fn collect_all(self) -> Result<alloc::vec::Vec<DTCFaultDetectionCounterRecord>, Error> {
+    pub fn collect_all(self) -> Result<alloc::vec::Vec<DtcFaultDetectionCounterRecord>, Error> {
         self.collect()
     }
 }
 
 impl Iterator for DtcFaultDetectionIter<'_> {
-    type Item = Result<DTCFaultDetectionCounterRecord, Error>;
+    type Item = Result<DtcFaultDetectionCounterRecord, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining.is_empty() {
@@ -584,17 +583,17 @@ impl Iterator for DtcFaultDetectionIter<'_> {
         if self.remaining.len() < 4 {
             return Some(Err(Error::IncorrectMessageLengthOrInvalidFormat));
         }
-        let dtc_record = DTCRecord::new(self.remaining[0], self.remaining[1], self.remaining[2]);
+        let dtc_record = DtcRecord::new(self.remaining[0], self.remaining[1], self.remaining[2]);
         let dtc_fault_detection_counter = self.remaining[3];
         self.remaining = &self.remaining[4..];
-        Some(Ok(DTCFaultDetectionCounterRecord {
+        Some(Ok(DtcFaultDetectionCounterRecord {
             dtc_record,
             dtc_fault_detection_counter,
         }))
     }
 }
 
-/// Lazy iterator over `(DTCSeverityMask, DTCRecord, DTCStatusMask)` triples from raw bytes.
+/// Lazy iterator over `(DtcSeverityMask, DtcRecord, DtcStatusMask)` triples from raw bytes.
 ///
 /// Each triple is 5 bytes: 1 severity + 3 DTC record + 1 status mask.
 #[derive(Clone, Debug)]
@@ -628,13 +627,13 @@ impl<'a> DtcSeverityAndStatusIter<'a> {
     #[cfg(feature = "alloc")]
     pub fn collect_all(
         self,
-    ) -> Result<alloc::vec::Vec<(DTCSeverityMask, DTCRecord, DTCStatusMask)>, Error> {
+    ) -> Result<alloc::vec::Vec<(DtcSeverityMask, DtcRecord, DtcStatusMask)>, Error> {
         self.collect()
     }
 }
 
 impl Iterator for DtcSeverityAndStatusIter<'_> {
-    type Item = Result<(DTCSeverityMask, DTCRecord, DTCStatusMask), Error>;
+    type Item = Result<(DtcSeverityMask, DtcRecord, DtcStatusMask), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining.is_empty() {
@@ -643,9 +642,9 @@ impl Iterator for DtcSeverityAndStatusIter<'_> {
         if self.remaining.len() < 5 {
             return Some(Err(Error::IncorrectMessageLengthOrInvalidFormat));
         }
-        let severity = DTCSeverityMask::from(self.remaining[0]);
-        let record = DTCRecord::new(self.remaining[1], self.remaining[2], self.remaining[3]);
-        let status = DTCStatusMask::from(self.remaining[4]);
+        let severity = DtcSeverityMask::from(self.remaining[0]);
+        let record = DtcRecord::new(self.remaining[1], self.remaining[2], self.remaining[3]);
+        let status = DtcStatusMask::from(self.remaining[4]);
         self.remaining = &self.remaining[5..];
         Some(Ok((severity, record, status)))
     }
@@ -668,47 +667,47 @@ impl Iterator for DtcSeverityAndStatusIter<'_> {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum ReadDTCInfoResponse<'a> {
+pub enum ReadDtcInfoResponse<'a> {
     /// Sub-functions 0x01, 0x07: count of DTCs matching a mask.
-    NumberOfDTCs {
+    NumberOfDtcs {
         /// Sub-function byte echo.
         sub_function_id: u8,
         /// Which status bits this server supports reporting. Same representation as
-        /// [`DTCStatusMask`], but a bit is 'on' when the server supports that status — a server
-        /// that does not support [`DTCStatusMask::WarningIndicatorRequested`] leaves that bit
+        /// [`DtcStatusMask`], but a bit is 'on' when the server supports that status — a server
+        /// that does not support [`DtcStatusMask::WarningIndicatorRequested`] leaves that bit
         /// 'off' and sets the rest.
-        status_availability_mask: DTCStatusMask,
+        status_availability_mask: DtcStatusMask,
         /// Number of matching DTCs.
         count: u16,
     },
-    /// Sub-functions 0x02, 0x0A-0x0E, 0x15: list of `(DTCRecord, DTCStatusMask)` pairs.
-    DTCList {
+    /// Sub-functions 0x02, 0x0A-0x0E, 0x15: list of `(DtcRecord, DtcStatusMask)` pairs.
+    DtcList {
         /// Sub-function byte echo.
         sub_function_id: u8,
         /// Which status bits this server supports reporting. Same representation as
-        /// [`DTCStatusMask`], but a bit is 'on' when the server supports that status — a server
-        /// that does not support [`DTCStatusMask::WarningIndicatorRequested`] leaves that bit
+        /// [`DtcStatusMask`], but a bit is 'on' when the server supports that status — a server
+        /// that does not support [`DtcStatusMask::WarningIndicatorRequested`] leaves that bit
         /// 'off' and sets the rest.
-        status_availability_mask: DTCStatusMask,
+        status_availability_mask: DtcStatusMask,
         /// Raw record bytes — use [`DtcAndStatusIter`] to iterate.
         #[cfg_attr(feature = "serde", serde(borrow))]
         raw_records: &'a [u8],
     },
     /// Sub-function 0x14: list of DTC fault detection counter records.
-    DTCFaultDetectionCounterList {
+    DtcFaultDetectionCounterList {
         /// Raw record bytes — use [`DtcFaultDetectionIter`] to iterate.
         #[cfg_attr(feature = "serde", serde(borrow))]
         raw_records: &'a [u8],
     },
     /// Sub-functions 0x08, 0x09: list of DTC severity records.
-    DTCSeverityList {
+    DtcSeverityList {
         /// Sub-function byte echo.
         sub_function_id: u8,
         /// Which status bits this server supports reporting. Same representation as
-        /// [`DTCStatusMask`], but a bit is 'on' when the server supports that status — a server
-        /// that does not support [`DTCStatusMask::WarningIndicatorRequested`] leaves that bit
+        /// [`DtcStatusMask`], but a bit is 'on' when the server supports that status — a server
+        /// that does not support [`DtcStatusMask::WarningIndicatorRequested`] leaves that bit
         /// 'off' and sets the rest.
-        status_availability_mask: DTCStatusMask,
+        status_availability_mask: DtcStatusMask,
         /// Raw `DTCAndSeverityRecord` bytes (6 bytes each: severity + DTC functional unit +
         /// 3-byte DTC + status). These differ from the 5-byte WWH-OBD records, so
         /// [`DtcSeverityAndStatusIter`] does **not** apply here; no severity-list iterator is
@@ -717,56 +716,59 @@ pub enum ReadDTCInfoResponse<'a> {
         raw_records: &'a [u8],
     },
     /// Sub-function 0x42: WWH-OBD DTC by mask with severity info.
-    WWHOBDDTCByMaskRecord {
+    WwhObdDtcByMaskRecord {
         /// Functional group identifier echo.
         functional_group_identifier: FunctionalGroupIdentifier,
         /// Which status bits this server supports reporting. Same representation as
-        /// [`DTCStatusMask`], but a bit is 'on' when the server supports that status — a server
-        /// that does not support [`DTCStatusMask::WarningIndicatorRequested`] leaves that bit
+        /// [`DtcStatusMask`], but a bit is 'on' when the server supports that status — a server
+        /// that does not support [`DtcStatusMask::WarningIndicatorRequested`] leaves that bit
         /// 'off' and sets the rest.
-        status_availability_mask: DTCStatusMask,
+        status_availability_mask: DtcStatusMask,
         /// Severity availability mask.
-        severity_availability_mask: DTCSeverityMask,
+        severity_availability_mask: DtcSeverityMask,
         /// DTC format identifier.
-        format_identifier: DTCFormatIdentifier,
+        format_identifier: DtcFormatIdentifier,
         /// Raw record bytes (5 bytes per record) — use [`DtcSeverityAndStatusIter`].
         #[cfg_attr(feature = "serde", serde(borrow))]
         raw_records: &'a [u8],
     },
 }
 
-impl<'a> ReadDTCInfoResponse<'a> {
-    /// Iterate `(DTCRecord, DTCStatusMask)` pairs for `DTCList` variants.
+impl<'a> ReadDtcInfoResponse<'a> {
+    /// Iterate `(DtcRecord, DtcStatusMask)` pairs for `DtcList` variants.
     ///
-    /// Returns `None` if this is not a `DTCList` variant.
+    /// Returns `None` if this is not a `DtcList` variant.
     #[must_use]
     pub fn dtc_and_status_iter(&self) -> Option<DtcAndStatusIter<'a>> {
         match self {
-            Self::DTCList { raw_records, .. } => Some(DtcAndStatusIter::new(raw_records)),
+            Self::DtcList { raw_records, .. } => Some(DtcAndStatusIter::new(raw_records)),
             _ => None,
         }
     }
 
-    /// Iterate fault detection counter records for the `DTCFaultDetectionCounterList` variant.
+    /// Iterate fault detection counter records for the `DtcFaultDetectionCounterList` variant.
     ///
     /// Returns `None` if this is not that variant.
     #[must_use]
     pub fn fault_detection_iter(&self) -> Option<DtcFaultDetectionIter<'a>> {
         match self {
-            Self::DTCFaultDetectionCounterList { raw_records } => {
+            Self::DtcFaultDetectionCounterList { raw_records } => {
                 Some(DtcFaultDetectionIter::new(raw_records))
             }
             _ => None,
         }
     }
 
-    /// Iterate severity/DTC/status triples for WWH-OBD variants.
+    /// Iterate the severity/DTC/status triples of `reportWWHOBDDTCByMaskRecord` (0x42).
     ///
-    /// Returns `None` if this is not a severity variant.
+    /// Returns `None` for every other variant, including
+    /// [`DtcSeverityList`](ReadDtcInfoResponse::DtcSeverityList) (0x08/0x09), whose
+    /// records are 6 bytes because they carry a `DTCFunctionalUnit` byte this one
+    /// does not.
     #[must_use]
     pub fn severity_and_status_iter(&self) -> Option<DtcSeverityAndStatusIter<'a>> {
         match self {
-            Self::WWHOBDDTCByMaskRecord { raw_records, .. } => {
+            Self::WwhObdDtcByMaskRecord { raw_records, .. } => {
                 Some(DtcSeverityAndStatusIter::new(raw_records))
             }
             _ => None,
@@ -774,7 +776,7 @@ impl<'a> ReadDTCInfoResponse<'a> {
     }
 }
 
-impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
+impl<'a> Decode<'a> for ReadDtcInfoResponse<'a> {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
@@ -795,10 +797,10 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
                         available: buf.len(),
                     }));
                 }
-                let status_availability_mask = DTCStatusMask::from(buf[0]);
+                let status_availability_mask = DtcStatusMask::from(buf[0]);
                 let count = u16::from_be_bytes([buf[1], buf[2]]);
                 Ok((
-                    Self::NumberOfDTCs {
+                    Self::NumberOfDtcs {
                         sub_function_id: subfunction_id,
                         status_availability_mask,
                         count,
@@ -813,9 +815,9 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
                         available: buf.len(),
                     }));
                 }
-                let status_availability_mask = DTCStatusMask::from(buf[0]);
+                let status_availability_mask = DtcStatusMask::from(buf[0]);
                 Ok((
-                    Self::DTCList {
+                    Self::DtcList {
                         sub_function_id: subfunction_id,
                         status_availability_mask,
                         raw_records: &buf[1..],
@@ -823,7 +825,7 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
                     &[],
                 ))
             }
-            0x14 => Ok((Self::DTCFaultDetectionCounterList { raw_records: buf }, &[])),
+            0x14 => Ok((Self::DtcFaultDetectionCounterList { raw_records: buf }, &[])),
             0x08 | 0x09 => {
                 if buf.is_empty() {
                     return Err(Error::InsufficientData(Incomplete {
@@ -831,9 +833,9 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
                         available: buf.len(),
                     }));
                 }
-                let status_availability_mask = DTCStatusMask::from(buf[0]);
+                let status_availability_mask = DtcStatusMask::from(buf[0]);
                 Ok((
-                    Self::DTCSeverityList {
+                    Self::DtcSeverityList {
                         sub_function_id: subfunction_id,
                         status_availability_mask,
                         raw_records: &buf[1..],
@@ -849,11 +851,11 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
                     }));
                 }
                 let functional_group_identifier = FunctionalGroupIdentifier::from(buf[0]);
-                let status_availability_mask = DTCStatusMask::from(buf[1]);
-                let severity_availability_mask = DTCSeverityMask::from(buf[2]);
-                let format_identifier = DTCFormatIdentifier::from(buf[3]);
+                let status_availability_mask = DtcStatusMask::from(buf[1]);
+                let severity_availability_mask = DtcSeverityMask::from(buf[2]);
+                let format_identifier = DtcFormatIdentifier::from(buf[3]);
                 Ok((
-                    Self::WWHOBDDTCByMaskRecord {
+                    Self::WwhObdDtcByMaskRecord {
                         functional_group_identifier,
                         status_availability_mask,
                         severity_availability_mask,
@@ -868,13 +870,13 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
     }
 }
 
-impl Encode for ReadDTCInfoResponse<'_> {
+impl Encode for ReadDtcInfoResponse<'_> {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
         let mut written = 0;
         match self {
-            Self::NumberOfDTCs {
+            Self::NumberOfDtcs {
                 sub_function_id,
                 status_availability_mask,
                 count,
@@ -883,12 +885,12 @@ impl Encode for ReadDTCInfoResponse<'_> {
                     .map_err(Error::io)?;
                 written += write_u16_be(writer, *count).map_err(Error::io)?;
             }
-            Self::DTCList {
+            Self::DtcList {
                 sub_function_id,
                 status_availability_mask,
                 raw_records,
             }
-            | Self::DTCSeverityList {
+            | Self::DtcSeverityList {
                 sub_function_id,
                 status_availability_mask,
                 raw_records,
@@ -897,11 +899,11 @@ impl Encode for ReadDTCInfoResponse<'_> {
                     .map_err(Error::io)?;
                 written += write_all(writer, raw_records).map_err(Error::io)?;
             }
-            Self::DTCFaultDetectionCounterList { raw_records } => {
+            Self::DtcFaultDetectionCounterList { raw_records } => {
                 written += write_u8(writer, 0x14).map_err(Error::io)?;
                 written += write_all(writer, raw_records).map_err(Error::io)?;
             }
-            Self::WWHOBDDTCByMaskRecord {
+            Self::WwhObdDtcByMaskRecord {
                 functional_group_identifier,
                 status_availability_mask,
                 severity_availability_mask,
@@ -933,21 +935,21 @@ mod derive_contract {
     #[cfg(feature = "serde")]
     use crate::test_util::assert_impl_serde;
 
-    const _: ReadDTCInfoRequest = ReadDTCInfoRequest::new(
-        ReadDTCInfoSubFunction::ReportDTC_ByStatusMask(DTCStatusMask::TestFailed),
+    const _: ReadDtcInfoRequest = ReadDtcInfoRequest::new(
+        ReadDtcInfoSubFunction::ReportDtcByStatusMask(DtcStatusMask::TestFailed),
     );
 
     #[test]
     fn eq_impls() {
-        assert_impl_eq::<ReadDTCInfoRequest>();
-        assert_impl_eq::<DTCFaultDetectionCounterRecord>();
-        assert_impl_eq::<ReadDTCInfoResponse<'static>>();
+        assert_impl_eq::<ReadDtcInfoRequest>();
+        assert_impl_eq::<DtcFaultDetectionCounterRecord>();
+        assert_impl_eq::<ReadDtcInfoResponse<'static>>();
     }
 
     #[cfg(feature = "serde")]
     #[test]
     fn serde_impls() {
-        assert_impl_serde::<ReadDTCInfoResponse<'static>>();
+        assert_impl_serde::<ReadDtcInfoResponse<'static>>();
     }
 }
 

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -8,11 +8,6 @@ use crate::{
     FunctionalGroupIdentifier, Incomplete, NegativeResponseCode,
 };
 
-/// Used for non-emissions related servers
-type DTCFaultDetectionCounter = u8;
-/// Used to address the respective user-defined DTC memory when retrieving DTCs
-type MemorySelection = u8;
-
 const READ_DTC_INFO_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 3] = [
     NegativeResponseCode::SubFunctionNotSupported,
     NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
@@ -257,13 +252,11 @@ mod read_dtc_info_request_encode_tests {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DTCFaultDetectionCounterRecord {
+    /// The DTC this counter belongs to.
     pub dtc_record: DTCRecord,
-    pub dtc_fault_detection_counter: DTCFaultDetectionCounter,
+    /// Fault detection counter, used for non-emissions related servers.
+    pub dtc_fault_detection_counter: u8,
 }
-
-/// Have to reference SAE J1979-DA for the corresponding DTC readiness groups and the [`FunctionalGroupIdentifier`]s
-/// This RGID depends on the functional group
-type DTCReadinessGroupIdentifier = u8; // RGID
 
 /// Subfunctions for the `ReadDTCInformation` service
 #[allow(non_camel_case_types)]
@@ -339,24 +332,19 @@ pub enum ReadDTCInfoSubFunction {
     /// 0x17
     ReportUserDefMemoryDTC_ByStatusMask(DTCStatusMask),
 
-    // TODO: UserDef and MemorySelection might just need to be u8
+    /// Parameter: `DTCRecord` (3 bytes)
+    /// Parameter: `DTCSnapshotRecordNumber`(1)
+    /// Parameter: `memorySelection`(1) — addresses the user-defined DTC memory to read from
+    ///
     /// 0x18
-    ReportUserDefMemoryDTCSnapshotRecord_ByDTCNumber(
-        DTCRecord,
-        DTCSnapshotRecordNumber,
-        MemorySelection,
-    ),
+    ReportUserDefMemoryDTCSnapshotRecord_ByDTCNumber(DTCRecord, DTCSnapshotRecordNumber, u8),
 
     /// Parameter: `DTCRecord` (3 bytes)
-    /// Parameter: DTCExtDataRecordNumber(1) (0xFF for all records)
-    /// Parameter: MemorySelection(1)
+    /// Parameter: `DTCExtDataRecordNumber`(1) (0xFF for all records)
+    /// Parameter: `memorySelection`(1) — addresses the user-defined DTC memory to read from
     ///
     /// 0x19
-    ReportUserDefMemoryDTCExtDataRecord_ByDTCNumber(
-        DTCRecord,
-        DTCExtDataRecordNumber,
-        MemorySelection,
-    ),
+    ReportUserDefMemoryDTCExtDataRecord_ByDTCNumber(DTCRecord, DTCExtDataRecordNumber, u8),
 
     /// * Parameter: DTCExtDataRecordNumber(1)
     ///
@@ -375,14 +363,13 @@ pub enum ReadDTCInfoSubFunction {
     /// 0x55
     ReportWWHOBDDTC_WithPermanentStatus(FunctionalGroupIdentifier),
 
-    /// * Parameter: FunctionalGroupIdentifier(1)
-    /// * Parameter: DTCReadinessGroupIdentifier(1)
+    /// * Parameter: `FunctionalGroupIdentifier`(1)
+    /// * Parameter: `DTCReadinessGroupIdentifier` (RGID, 1 byte). The RGID depends on the
+    ///   functional group; see SAE J1979-DA for the readiness groups that correspond to each
+    ///   [`FunctionalGroupIdentifier`].
     ///
     /// 0x56
-    ReportDTCInformation_ByDTCReadinessGroupIdentifier(
-        FunctionalGroupIdentifier,
-        DTCReadinessGroupIdentifier,
-    ),
+    ReportDTCInformation_ByDTCReadinessGroupIdentifier(FunctionalGroupIdentifier, u8),
     /// 0x42-0x54, 0x57-0x7F
     ISOSAEReserved(u8),
 }
@@ -491,11 +478,6 @@ impl Encode for ReadDTCInfoSubFunction {
         Ok(written)
     }
 }
-
-/// Same representation as [`DTCStatusMask`] but with the bits 'on' representing the DTC status supported by the server
-/// IE if the server doesn't support [`DTCStatusMask::WarningIndicatorRequested`] then the bit for that status will be 'off'
-/// and all other bits will be 'on'
-type DTCStatusAvailabilityMask = DTCStatusMask;
 
 // ---------------------------------------------------------------------------
 // no_std RX types with lazy iterators
@@ -691,8 +673,11 @@ pub enum ReadDTCInfoResponse<'a> {
     NumberOfDTCs {
         /// Sub-function byte echo.
         sub_function_id: u8,
-        /// DTC status availability mask.
-        status_availability_mask: DTCStatusAvailabilityMask,
+        /// Which status bits this server supports reporting. Same representation as
+        /// [`DTCStatusMask`], but a bit is 'on' when the server supports that status — a server
+        /// that does not support [`DTCStatusMask::WarningIndicatorRequested`] leaves that bit
+        /// 'off' and sets the rest.
+        status_availability_mask: DTCStatusMask,
         /// Number of matching DTCs.
         count: u16,
     },
@@ -700,8 +685,11 @@ pub enum ReadDTCInfoResponse<'a> {
     DTCList {
         /// Sub-function byte echo.
         sub_function_id: u8,
-        /// DTC status availability mask.
-        status_availability_mask: DTCStatusAvailabilityMask,
+        /// Which status bits this server supports reporting. Same representation as
+        /// [`DTCStatusMask`], but a bit is 'on' when the server supports that status — a server
+        /// that does not support [`DTCStatusMask::WarningIndicatorRequested`] leaves that bit
+        /// 'off' and sets the rest.
+        status_availability_mask: DTCStatusMask,
         /// Raw record bytes — use [`DtcAndStatusIter`] to iterate.
         #[cfg_attr(feature = "serde", serde(borrow))]
         raw_records: &'a [u8],
@@ -716,8 +704,11 @@ pub enum ReadDTCInfoResponse<'a> {
     DTCSeverityList {
         /// Sub-function byte echo.
         sub_function_id: u8,
-        /// DTC status availability mask.
-        status_availability_mask: DTCStatusAvailabilityMask,
+        /// Which status bits this server supports reporting. Same representation as
+        /// [`DTCStatusMask`], but a bit is 'on' when the server supports that status — a server
+        /// that does not support [`DTCStatusMask::WarningIndicatorRequested`] leaves that bit
+        /// 'off' and sets the rest.
+        status_availability_mask: DTCStatusMask,
         /// Raw `DTCAndSeverityRecord` bytes (6 bytes each: severity + DTC functional unit +
         /// 3-byte DTC + status). These differ from the 5-byte WWH-OBD records, so
         /// [`DtcSeverityAndStatusIter`] does **not** apply here; no severity-list iterator is
@@ -729,8 +720,11 @@ pub enum ReadDTCInfoResponse<'a> {
     WWHOBDDTCByMaskRecord {
         /// Functional group identifier echo.
         functional_group_identifier: FunctionalGroupIdentifier,
-        /// DTC status availability mask.
-        status_availability_mask: DTCStatusAvailabilityMask,
+        /// Which status bits this server supports reporting. Same representation as
+        /// [`DTCStatusMask`], but a bit is 'on' when the server supports that status — a server
+        /// that does not support [`DTCStatusMask::WarningIndicatorRequested`] leaves that bit
+        /// 'off' and sets the rest.
+        status_availability_mask: DTCStatusMask,
         /// Severity availability mask.
         severity_availability_mask: DTCSeverityMask,
         /// DTC format identifier.
@@ -801,7 +795,7 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
                         available: buf.len(),
                     }));
                 }
-                let status_availability_mask = DTCStatusAvailabilityMask::from(buf[0]);
+                let status_availability_mask = DTCStatusMask::from(buf[0]);
                 let count = u16::from_be_bytes([buf[1], buf[2]]);
                 Ok((
                     Self::NumberOfDTCs {
@@ -819,7 +813,7 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
                         available: buf.len(),
                     }));
                 }
-                let status_availability_mask = DTCStatusAvailabilityMask::from(buf[0]);
+                let status_availability_mask = DTCStatusMask::from(buf[0]);
                 Ok((
                     Self::DTCList {
                         sub_function_id: subfunction_id,
@@ -837,7 +831,7 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
                         available: buf.len(),
                     }));
                 }
-                let status_availability_mask = DTCStatusAvailabilityMask::from(buf[0]);
+                let status_availability_mask = DTCStatusMask::from(buf[0]);
                 Ok((
                     Self::DTCSeverityList {
                         sub_function_id: subfunction_id,
@@ -855,7 +849,7 @@ impl<'a> Decode<'a> for ReadDTCInfoResponse<'a> {
                     }));
                 }
                 let functional_group_identifier = FunctionalGroupIdentifier::from(buf[0]);
-                let status_availability_mask = DTCStatusAvailabilityMask::from(buf[1]);
+                let status_availability_mask = DTCStatusMask::from(buf[1]);
                 let severity_availability_mask = DTCSeverityMask::from(buf[2]);
                 let format_identifier = DTCFormatIdentifier::from(buf[3]);
                 Ok((

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -24,7 +24,7 @@ fn size_param_width(a: u128, b: u128) -> usize {
 #[repr(u8)]
 pub enum FileOperationMode {
     /// ISO/SAE reserved (`0x00`, `0x07–0xFF`).
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
     /// Add a file to the server
     AddFile = 0x01,
     /// Delete the specified file from the server
@@ -44,7 +44,7 @@ pub enum FileOperationMode {
 impl From<FileOperationMode> for u8 {
     fn from(value: FileOperationMode) -> Self {
         match value {
-            FileOperationMode::ISOSAEReserved(value) => value,
+            FileOperationMode::IsoSaeReserved(value) => value,
             FileOperationMode::AddFile => 0x01,
             FileOperationMode::DeleteFile => 0x02,
             FileOperationMode::ReplaceFile => 0x03,
@@ -66,7 +66,7 @@ impl TryFrom<u8> for FileOperationMode {
             0x04 => Ok(Self::ReadFile),
             0x05 => Ok(Self::ReadDir),
             0x06 => Ok(Self::ResumeFile),
-            0x00 | 0x07..=0xFF => Ok(Self::ISOSAEReserved(value)),
+            0x00 | 0x07..=0xFF => Ok(Self::IsoSaeReserved(value)),
         }
     }
 }
@@ -742,7 +742,7 @@ impl<'a> Decode<'a> for RequestFileTransferRequest<'a> {
                 };
                 Ok((value, rest))
             }
-            FileOperationMode::ISOSAEReserved(b) => Err(Error::InvalidFileOperationMode(b)),
+            FileOperationMode::IsoSaeReserved(b) => Err(Error::InvalidFileOperationMode(b)),
         }
     }
 }
@@ -851,7 +851,7 @@ impl<'a> Decode<'a> for RequestFileTransferResponse<'a> {
                 let (pos, rest) = PositionPayload::decode(&rest[1..])?;
                 Ok((Self::ResumeFile(mode, sent, dfi, pos), rest))
             }
-            FileOperationMode::ISOSAEReserved(b) => Err(Error::InvalidFileOperationMode(b)),
+            FileOperationMode::IsoSaeReserved(b) => Err(Error::InvalidFileOperationMode(b)),
         }
     }
 }
@@ -878,7 +878,7 @@ mod request_tests {
         assert_eq!(ReadDir, FileOperationMode::try_from(0x05).unwrap());
         assert_eq!(ResumeFile, FileOperationMode::try_from(0x06).unwrap());
         assert_eq!(
-            ISOSAEReserved(0x07),
+            IsoSaeReserved(0x07),
             FileOperationMode::try_from(0x07).unwrap()
         );
     }

--- a/src/services/security_access.rs
+++ b/src/services/security_access.rs
@@ -53,16 +53,16 @@ pub enum SecurityAccessType {
     /// Construct through [`SecurityAccessType::try_from`] so the raw byte is range-checked
     /// and can never collide with the SPRMIB bit.
     #[non_exhaustive]
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
     /// `RequestSeed` with the level of security defined by the vehicle manufacturer
     RequestSeed(SecurityAccessLevel),
     /// `SendKey` with the level of security defined by the vehicle manufacturer
     SendKey(SecurityAccessLevel),
     /// `RequestSeed` with different levels of security defined for end of life
     /// activation of on-board pyrotechnic devices
-    ISO26021_2Values,
+    Iso26021_2Values,
     /// `SendKey` with different levels of security defined for end of life activation
-    ISO26021_2SendKeyValues,
+    Iso26021_2SendKeyValues,
     /// This range of values is reserved for system supplier specific use
     ///
     /// Construct through [`SecurityAccessType::try_from`] so the raw byte is range-checked
@@ -75,11 +75,11 @@ impl From<SecurityAccessType> for u8 {
     #[allow(clippy::match_same_arms)]
     fn from(value: SecurityAccessType) -> Self {
         match value {
-            SecurityAccessType::ISOSAEReserved(val) => val,
+            SecurityAccessType::IsoSaeReserved(val) => val,
             SecurityAccessType::RequestSeed(level) => level.value(),
             SecurityAccessType::SendKey(level) => level.value(),
-            SecurityAccessType::ISO26021_2Values => 0x5F,
-            SecurityAccessType::ISO26021_2SendKeyValues => 0x60,
+            SecurityAccessType::Iso26021_2Values => 0x5F,
+            SecurityAccessType::Iso26021_2SendKeyValues => 0x60,
             SecurityAccessType::SystemSupplierSpecific(val) => val,
         }
     }
@@ -89,7 +89,7 @@ impl TryFrom<u8> for SecurityAccessType {
     type Error = Error;
     fn try_from(value: u8) -> Result<Self, Error> {
         match value {
-            0x00 | 0x43..=0x5E | 0x7F => Ok(Self::ISOSAEReserved(value)),
+            0x00 | 0x43..=0x5E | 0x7F => Ok(Self::IsoSaeReserved(value)),
             // Security requests alternate, with odd numbers being seed requests,
             // and even numbers being send key requests
             0x01..=0x42 => {
@@ -100,8 +100,8 @@ impl TryFrom<u8> for SecurityAccessType {
                     Ok(Self::SendKey(SecurityAccessLevel(value)))
                 }
             }
-            0x5F => Ok(Self::ISO26021_2Values),
-            0x60 => Ok(Self::ISO26021_2SendKeyValues),
+            0x5F => Ok(Self::Iso26021_2Values),
+            0x60 => Ok(Self::Iso26021_2SendKeyValues),
             0x61..=0x7E => Ok(Self::SystemSupplierSpecific(value)),
             _ => Err(Error::InvalidSecurityAccessType(value)),
         }
@@ -127,7 +127,7 @@ mod security_access_type_tests {
     fn security_access_type_from_all_u8_values() {
         assert_eq!(
             SecurityAccessType::try_from(0).unwrap(),
-            SecurityAccessType::ISOSAEReserved(0)
+            SecurityAccessType::IsoSaeReserved(0)
         );
         for value in &REQUEST_SEED_VALUES {
             assert_eq!(
@@ -144,16 +144,16 @@ mod security_access_type_tests {
         for i in 0x43..=0x5E {
             assert_eq!(
                 SecurityAccessType::try_from(i).unwrap(),
-                SecurityAccessType::ISOSAEReserved(i)
+                SecurityAccessType::IsoSaeReserved(i)
             );
         }
         assert_eq!(
             SecurityAccessType::try_from(0x5F).unwrap(),
-            SecurityAccessType::ISO26021_2Values
+            SecurityAccessType::Iso26021_2Values
         );
         assert_eq!(
             SecurityAccessType::try_from(0x60).unwrap(),
-            SecurityAccessType::ISO26021_2SendKeyValues
+            SecurityAccessType::Iso26021_2SendKeyValues
         );
         for i in 0x61..=0x7E {
             assert_eq!(
@@ -163,7 +163,7 @@ mod security_access_type_tests {
         }
         assert_eq!(
             SecurityAccessType::try_from(0x7F).unwrap(),
-            SecurityAccessType::ISOSAEReserved(0x7F)
+            SecurityAccessType::IsoSaeReserved(0x7F)
         );
         for i in 0x80..=0xFF {
             match SecurityAccessType::try_from(i).unwrap_err() {

--- a/src/services/tester_present.rs
+++ b/src/services/tester_present.rs
@@ -21,7 +21,7 @@ enum ZeroSubFunction {
     /// Request and response. Indicates that no value beside the SPR Message Indication Bit is supported by this service.
     NoSubFunctionSupported,
     /// Request only.
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
 }
 
 impl Default for ZeroSubFunction {
@@ -35,7 +35,7 @@ impl From<ZeroSubFunction> for u8 {
     fn from(sub_function: ZeroSubFunction) -> Self {
         match sub_function {
             ZeroSubFunction::NoSubFunctionSupported => NO_SUBFUNCTION_VALUE,
-            ZeroSubFunction::ISOSAEReserved(value) => value,
+            ZeroSubFunction::IsoSaeReserved(value) => value,
         }
     }
 }
@@ -45,7 +45,7 @@ impl TryFrom<u8> for ZeroSubFunction {
     fn try_from(value: u8) -> Result<Self, Error> {
         match value {
             NO_SUBFUNCTION_VALUE => Ok(ZeroSubFunction::NoSubFunctionSupported),
-            0x01..=0x7F => Ok(ZeroSubFunction::ISOSAEReserved(value)),
+            0x01..=0x7F => Ok(ZeroSubFunction::IsoSaeReserved(value)),
             _ => Err(Error::InvalidTesterPresentType(value)),
         }
     }
@@ -181,7 +181,7 @@ mod test {
                     assert_eq!(try_result.unwrap(), ZeroSubFunction::NoSubFunctionSupported);
                 }
                 0x01..=0x7F => {
-                    assert!(matches!(try_result, Ok(ZeroSubFunction::ISOSAEReserved(_))));
+                    assert!(matches!(try_result, Ok(ZeroSubFunction::IsoSaeReserved(_))));
                 }
                 _ => {
                     assert!(matches!(
@@ -198,7 +198,7 @@ mod test {
         assert_eq!(u8::from(ZeroSubFunction::default()), NO_SUBFUNCTION_VALUE);
 
         for i in 0x01..=0x7F {
-            let result = ZeroSubFunction::ISOSAEReserved(i);
+            let result = ZeroSubFunction::IsoSaeReserved(i);
             assert_eq!(u8::from(result), i);
         }
     }

--- a/src/shared/diagnostic_identifier.rs
+++ b/src/shared/diagnostic_identifier.rs
@@ -8,10 +8,10 @@
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum, clap::Parser))]
 #[derive(Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum UDSIdentifier {
+pub enum UdsIdentifier {
     /// DID reserved by ISO/SAE (ranges `0x0000–0x00FF`, `0xFF02–0xFFFF`).
     #[cfg_attr(feature = "clap", clap(skip))]
-    ISOSAEReserved(u16),
+    IsoSaeReserved(u16),
     /// Vehicle-manufacturer–specific DID (multiple ranges, see ISO 14229-1 Table C.1).
     #[cfg_attr(feature = "clap", clap(skip))]
     VehicleManufacturerSpecific(u16),
@@ -38,13 +38,13 @@ pub enum UDSIdentifier {
     DynamicallyDefinedDataIdentifier(u16),
     /// OBD data identifier (`0xF400–0xF5FF`, `0xF700–0xF7FF`).
     #[cfg_attr(feature = "clap", clap(skip))]
-    OBDDataIdentifier(u16),
+    ObdDataIdentifier(u16),
     /// OBD monitor data identifier (`0xF600–0xF6FF`).
     #[cfg_attr(feature = "clap", clap(skip))]
-    OBDMonitorDataIdentifier(u16),
+    ObdMonitorDataIdentifier(u16),
     /// OBD info-type data identifier (`0xF800–0xF8FF`).
     #[cfg_attr(feature = "clap", clap(skip))]
-    OBDInfoTypeDataIdentifier(u16),
+    ObdInfoTypeDataIdentifier(u16),
     /// Tachograph data identifier (`0xF900–0xF9FF`).
     #[cfg_attr(feature = "clap", clap(skip))]
     TachographDataIdentifier(u16),
@@ -52,14 +52,14 @@ pub enum UDSIdentifier {
     #[cfg_attr(feature = "clap", clap(skip))]
     AirbagDeploymentDataIdentifier(u16),
     /// Number of EDR devices (`0xFA10`).
-    NumberOfEDRDevices,
+    NumberOfEdrDevices,
     /// EDR identification (`0xFA11`).
-    EDRIdentification,
+    EdrIdentification,
     /// EDR device address information (`0xFA12`).
-    EDRDeviceAddressInformation,
+    EdrDeviceAddressInformation,
     /// EDR entries (`0xFA13–0xFA18`).
     #[cfg_attr(feature = "clap", clap(skip))]
-    EDREntries(u16),
+    EdrEntries(u16),
     /// Safety system data identifier (`0xFA19–0xFAFF`).
     #[cfg_attr(feature = "clap", clap(skip))]
     SafetySystemDataIdentifier(u16),
@@ -80,16 +80,16 @@ pub enum UDSIdentifier {
     /// Vehicle manufacturer spare-part number (`0xF187`).
     VehicleManufacturerSparePartNumber,
     /// Vehicle manufacturer ECU software number (`0xF188`).
-    VehicleManufacturerECUSoftwareNumber,
+    VehicleManufacturerEcuSoftwareNumber,
     /// Vehicle manufacturer ECU software version number (`0xF189`).
-    VehicleManufacturerECUSoftwareVersionNumber,
+    VehicleManufacturerEcuSoftwareVersionNumber,
     /// System supplier identifier (`0xF18A`).
     SystemSupplierIdentifier,
     /// This value shall be used to reference the ECU (server) manufacturing date. Record data content and format shall be
     /// unsigned numeric, ASCII or BCD, and shall be ordered as Year, Month, Day.
-    ECUManufacturingData,
+    EcuManufacturingData,
     /// Get the serial number of the ECU, format shall be server specific.
-    ECUSerialNumber,
+    EcuSerialNumber,
     /// Request the supported functional units of the ECU.
     SupportedFunctionalUnits,
     /// This value shall be used to reference the vehicle manufacturer order number for a kit (assembled parts bought as a whole for
@@ -100,17 +100,17 @@ pub enum UDSIdentifier {
     /// Recursive ASCII string
     RegulationXSoftwareIdentificationNumbers,
     /// Vehicle Identification Number (`0xF190`).
-    VIN,
+    Vin,
     /// Vehicle manufacturer ECU hardware number (`0xF191`).
-    VehicleManufacturerECUHardwareNumber,
+    VehicleManufacturerEcuHardwareNumber,
     /// System supplier ECU hardware number (`0xF192`).
-    SystemSupplierECUHardwareNumber,
+    SystemSupplierEcuHardwareNumber,
     /// System supplier ECU hardware version number (`0xF193`).
-    SystemSupplierECUHardwareVersionNumber,
+    SystemSupplierEcuHardwareVersionNumber,
     /// System supplier ECU software number (`0xF194`).
-    SystemSupplierECUSoftwareNumber,
+    SystemSupplierEcuSoftwareNumber,
     /// System supplier ECU software version number (`0xF195`).
-    SystemSupplierECUSoftwareVersionNumber,
+    SystemSupplierEcuSoftwareVersionNumber,
     /// Exhaust regulation or type approval number (`0xF196`).
     ExhaustRegulationOrTypeApprovalNumber,
     /// System name or engine type (`0xF197`).
@@ -127,22 +127,22 @@ pub enum UDSIdentifier {
     /// Calibration equipment software number (`0xF19C`).
     CalibrationEquipmentSoftwareNumber,
     /// ECU installation date (`0xF19D`).
-    ECUInstallationDate,
+    EcuInstallationDate,
     /// ODX file identifier (`0xF19E`).
-    ODXFile,
+    OdxFile,
     /// Used to reference the entity data identifier for a secured data transfer
     Entity,
     /// UDS version data (`0xFF00`).
-    UDSVersionData,
+    UdsVersionData,
     /// Reserved for ISO 15765-5 (`0xFF01`).
-    ReservedForISO15765_5,
+    ReservedForIso15765_5,
 }
 
-impl From<u16> for UDSIdentifier {
+impl From<u16> for UdsIdentifier {
     #[allow(clippy::match_same_arms)]
     fn from(value: u16) -> Self {
         match value {
-            0x0000..=0x00FF => Self::ISOSAEReserved(value),
+            0x0000..=0x00FF => Self::IsoSaeReserved(value),
             0x0100..=0xA5FF => Self::VehicleManufacturerSpecific(value),
             0xA600..=0xA7FF => Self::ReservedForLegislativeUse(value),
             0xA800..=0xACFF => Self::VehicleManufacturerSpecific(value),
@@ -163,20 +163,20 @@ impl From<u16> for UDSIdentifier {
             0xF185 => Self::ApplicationDataFingerprint,
             0xF186 => Self::ActiveDiagnosticSession,
             0xF187 => Self::VehicleManufacturerSparePartNumber,
-            0xF188 => Self::VehicleManufacturerECUSoftwareNumber,
-            0xF189 => Self::VehicleManufacturerECUSoftwareVersionNumber,
+            0xF188 => Self::VehicleManufacturerEcuSoftwareNumber,
+            0xF189 => Self::VehicleManufacturerEcuSoftwareVersionNumber,
             0xF18A => Self::SystemSupplierIdentifier,
-            0xF18B => Self::ECUManufacturingData,
-            0xF18C => Self::ECUSerialNumber,
+            0xF18B => Self::EcuManufacturingData,
+            0xF18C => Self::EcuSerialNumber,
             0xF18D => Self::SupportedFunctionalUnits,
             0xF18E => Self::VehicleManufacturerKitAssemblyPartNumber,
             0xF18F => Self::RegulationXSoftwareIdentificationNumbers,
-            0xF190 => Self::VIN,
-            0xF191 => Self::VehicleManufacturerECUHardwareNumber,
-            0xF192 => Self::SystemSupplierECUHardwareNumber,
-            0xF193 => Self::SystemSupplierECUHardwareVersionNumber,
-            0xF194 => Self::SystemSupplierECUSoftwareNumber,
-            0xF195 => Self::SystemSupplierECUSoftwareVersionNumber,
+            0xF190 => Self::Vin,
+            0xF191 => Self::VehicleManufacturerEcuHardwareNumber,
+            0xF192 => Self::SystemSupplierEcuHardwareNumber,
+            0xF193 => Self::SystemSupplierEcuHardwareVersionNumber,
+            0xF194 => Self::SystemSupplierEcuSoftwareNumber,
+            0xF195 => Self::SystemSupplierEcuSoftwareVersionNumber,
             0xF196 => Self::ExhaustRegulationOrTypeApprovalNumber,
             0xF197 => Self::SystemNameOrEngineType,
             0xF198 => Self::RepairShopOrTesterSerialNumber,
@@ -184,102 +184,102 @@ impl From<u16> for UDSIdentifier {
             0xF19A => Self::CalibrationRepairShopCodeOrCalibrationEquipmentSerialNumber,
             0xF19B => Self::CalibrationDate,
             0xF19C => Self::CalibrationEquipmentSoftwareNumber,
-            0xF19D => Self::ECUInstallationDate,
-            0xF19E => Self::ODXFile,
+            0xF19D => Self::EcuInstallationDate,
+            0xF19E => Self::OdxFile,
             0xF19F => Self::Entity,
             0xF1A0..=0xF1EF => Self::IdentificationOptionVehicleManufacturerSpecific(value),
             0xF1F0..=0xF1FF => Self::IdentificationOptionSystemSupplierSpecific(value),
             0xF200..=0xF2FF => Self::PeriodicDataIdentifier(value),
             0xF300..=0xF3FF => Self::DynamicallyDefinedDataIdentifier(value),
-            0xF400..=0xF5FF => Self::OBDDataIdentifier(value),
-            0xF600..=0xF6FF => Self::OBDMonitorDataIdentifier(value),
-            0xF700..=0xF7FF => Self::OBDDataIdentifier(value),
-            0xF800..=0xF8FF => Self::OBDInfoTypeDataIdentifier(value),
+            0xF400..=0xF5FF => Self::ObdDataIdentifier(value),
+            0xF600..=0xF6FF => Self::ObdMonitorDataIdentifier(value),
+            0xF700..=0xF7FF => Self::ObdDataIdentifier(value),
+            0xF800..=0xF8FF => Self::ObdInfoTypeDataIdentifier(value),
             0xF900..=0xF9FF => Self::TachographDataIdentifier(value),
             0xFA00..=0xFA0F => Self::AirbagDeploymentDataIdentifier(value),
-            0xFA10 => Self::NumberOfEDRDevices,
-            0xFA11 => Self::EDRIdentification,
-            0xFA12 => Self::EDRDeviceAddressInformation,
-            0xFA13..=0xFA18 => Self::EDREntries(value),
+            0xFA10 => Self::NumberOfEdrDevices,
+            0xFA11 => Self::EdrIdentification,
+            0xFA12 => Self::EdrDeviceAddressInformation,
+            0xFA13..=0xFA18 => Self::EdrEntries(value),
             0xFA19..=0xFAFF => Self::SafetySystemDataIdentifier(value),
             0xFB00..=0xFCFF => Self::ReservedForLegislativeUse(value),
             0xFD00..=0xFEFF => Self::SystemSupplierSpecific(value),
-            0xFF00 => Self::UDSVersionData,
-            0xFF01 => Self::ReservedForISO15765_5,
-            0xFF02..=0xFFFF => Self::ISOSAEReserved(value),
+            0xFF00 => Self::UdsVersionData,
+            0xFF01 => Self::ReservedForIso15765_5,
+            0xFF02..=0xFFFF => Self::IsoSaeReserved(value),
         }
     }
 }
 
-impl From<UDSIdentifier> for u16 {
+impl From<UdsIdentifier> for u16 {
     #[allow(clippy::match_same_arms)]
-    fn from(value: UDSIdentifier) -> Self {
+    fn from(value: UdsIdentifier) -> Self {
         match value {
-            UDSIdentifier::ISOSAEReserved(v) => v,
-            UDSIdentifier::VehicleManufacturerSpecific(v) => v,
-            UDSIdentifier::SystemSupplierSpecific(v) => v,
-            UDSIdentifier::ReservedForLegislativeUse(v) => v,
-            UDSIdentifier::NetworkConfigDataForTractorTrailer(v) => v,
-            UDSIdentifier::IdentificationOptionVehicleManufacturerSpecific(v) => v,
-            UDSIdentifier::IdentificationOptionSystemSupplierSpecific(v) => v,
-            UDSIdentifier::PeriodicDataIdentifier(v) => v,
-            UDSIdentifier::DynamicallyDefinedDataIdentifier(v) => v,
-            UDSIdentifier::OBDDataIdentifier(v) => v,
-            UDSIdentifier::OBDMonitorDataIdentifier(v) => v,
-            UDSIdentifier::OBDInfoTypeDataIdentifier(v) => v,
-            UDSIdentifier::TachographDataIdentifier(v) => v,
-            UDSIdentifier::AirbagDeploymentDataIdentifier(v) => v,
-            UDSIdentifier::NumberOfEDRDevices => 0xFA10,
-            UDSIdentifier::EDRIdentification => 0xFA11,
-            UDSIdentifier::EDRDeviceAddressInformation => 0xFA12,
-            UDSIdentifier::EDREntries(v) => v,
-            UDSIdentifier::SafetySystemDataIdentifier(v) => v,
-            UDSIdentifier::BootSoftwareIdentification => 0xF180,
-            UDSIdentifier::ApplicationSoftwareIdentification => 0xF181,
-            UDSIdentifier::ApplicationDataIdentification => 0xF182,
-            UDSIdentifier::BootSoftwareFingerprint => 0xF183,
-            UDSIdentifier::ApplicationSoftwareFingerprint => 0xF184,
-            UDSIdentifier::ApplicationDataFingerprint => 0xF185,
-            UDSIdentifier::ActiveDiagnosticSession => 0xF186,
-            UDSIdentifier::VehicleManufacturerSparePartNumber => 0xF187,
-            UDSIdentifier::VehicleManufacturerECUSoftwareNumber => 0xF188,
-            UDSIdentifier::VehicleManufacturerECUSoftwareVersionNumber => 0xF189,
-            UDSIdentifier::SystemSupplierIdentifier => 0xF18A,
-            UDSIdentifier::ECUManufacturingData => 0xF18B,
-            UDSIdentifier::ECUSerialNumber => 0xF18C,
-            UDSIdentifier::SupportedFunctionalUnits => 0xF18D,
-            UDSIdentifier::VehicleManufacturerKitAssemblyPartNumber => 0xF18E,
-            UDSIdentifier::RegulationXSoftwareIdentificationNumbers => 0xF18F,
-            UDSIdentifier::VIN => 0xF190,
-            UDSIdentifier::VehicleManufacturerECUHardwareNumber => 0xF191,
-            UDSIdentifier::SystemSupplierECUHardwareNumber => 0xF192,
-            UDSIdentifier::SystemSupplierECUHardwareVersionNumber => 0xF193,
-            UDSIdentifier::SystemSupplierECUSoftwareNumber => 0xF194,
-            UDSIdentifier::SystemSupplierECUSoftwareVersionNumber => 0xF195,
-            UDSIdentifier::ExhaustRegulationOrTypeApprovalNumber => 0xF196,
-            UDSIdentifier::SystemNameOrEngineType => 0xF197,
-            UDSIdentifier::RepairShopOrTesterSerialNumber => 0xF198,
-            UDSIdentifier::ProgrammingDate => 0xF199,
-            UDSIdentifier::CalibrationRepairShopCodeOrCalibrationEquipmentSerialNumber => 0xF19A,
-            UDSIdentifier::CalibrationDate => 0xF19B,
-            UDSIdentifier::CalibrationEquipmentSoftwareNumber => 0xF19C,
-            UDSIdentifier::ECUInstallationDate => 0xF19D,
-            UDSIdentifier::ODXFile => 0xF19E,
-            UDSIdentifier::Entity => 0xF19F,
-            UDSIdentifier::UDSVersionData => 0xFF00,
-            UDSIdentifier::ReservedForISO15765_5 => 0xFF01,
+            UdsIdentifier::IsoSaeReserved(v) => v,
+            UdsIdentifier::VehicleManufacturerSpecific(v) => v,
+            UdsIdentifier::SystemSupplierSpecific(v) => v,
+            UdsIdentifier::ReservedForLegislativeUse(v) => v,
+            UdsIdentifier::NetworkConfigDataForTractorTrailer(v) => v,
+            UdsIdentifier::IdentificationOptionVehicleManufacturerSpecific(v) => v,
+            UdsIdentifier::IdentificationOptionSystemSupplierSpecific(v) => v,
+            UdsIdentifier::PeriodicDataIdentifier(v) => v,
+            UdsIdentifier::DynamicallyDefinedDataIdentifier(v) => v,
+            UdsIdentifier::ObdDataIdentifier(v) => v,
+            UdsIdentifier::ObdMonitorDataIdentifier(v) => v,
+            UdsIdentifier::ObdInfoTypeDataIdentifier(v) => v,
+            UdsIdentifier::TachographDataIdentifier(v) => v,
+            UdsIdentifier::AirbagDeploymentDataIdentifier(v) => v,
+            UdsIdentifier::NumberOfEdrDevices => 0xFA10,
+            UdsIdentifier::EdrIdentification => 0xFA11,
+            UdsIdentifier::EdrDeviceAddressInformation => 0xFA12,
+            UdsIdentifier::EdrEntries(v) => v,
+            UdsIdentifier::SafetySystemDataIdentifier(v) => v,
+            UdsIdentifier::BootSoftwareIdentification => 0xF180,
+            UdsIdentifier::ApplicationSoftwareIdentification => 0xF181,
+            UdsIdentifier::ApplicationDataIdentification => 0xF182,
+            UdsIdentifier::BootSoftwareFingerprint => 0xF183,
+            UdsIdentifier::ApplicationSoftwareFingerprint => 0xF184,
+            UdsIdentifier::ApplicationDataFingerprint => 0xF185,
+            UdsIdentifier::ActiveDiagnosticSession => 0xF186,
+            UdsIdentifier::VehicleManufacturerSparePartNumber => 0xF187,
+            UdsIdentifier::VehicleManufacturerEcuSoftwareNumber => 0xF188,
+            UdsIdentifier::VehicleManufacturerEcuSoftwareVersionNumber => 0xF189,
+            UdsIdentifier::SystemSupplierIdentifier => 0xF18A,
+            UdsIdentifier::EcuManufacturingData => 0xF18B,
+            UdsIdentifier::EcuSerialNumber => 0xF18C,
+            UdsIdentifier::SupportedFunctionalUnits => 0xF18D,
+            UdsIdentifier::VehicleManufacturerKitAssemblyPartNumber => 0xF18E,
+            UdsIdentifier::RegulationXSoftwareIdentificationNumbers => 0xF18F,
+            UdsIdentifier::Vin => 0xF190,
+            UdsIdentifier::VehicleManufacturerEcuHardwareNumber => 0xF191,
+            UdsIdentifier::SystemSupplierEcuHardwareNumber => 0xF192,
+            UdsIdentifier::SystemSupplierEcuHardwareVersionNumber => 0xF193,
+            UdsIdentifier::SystemSupplierEcuSoftwareNumber => 0xF194,
+            UdsIdentifier::SystemSupplierEcuSoftwareVersionNumber => 0xF195,
+            UdsIdentifier::ExhaustRegulationOrTypeApprovalNumber => 0xF196,
+            UdsIdentifier::SystemNameOrEngineType => 0xF197,
+            UdsIdentifier::RepairShopOrTesterSerialNumber => 0xF198,
+            UdsIdentifier::ProgrammingDate => 0xF199,
+            UdsIdentifier::CalibrationRepairShopCodeOrCalibrationEquipmentSerialNumber => 0xF19A,
+            UdsIdentifier::CalibrationDate => 0xF19B,
+            UdsIdentifier::CalibrationEquipmentSoftwareNumber => 0xF19C,
+            UdsIdentifier::EcuInstallationDate => 0xF19D,
+            UdsIdentifier::OdxFile => 0xF19E,
+            UdsIdentifier::Entity => 0xF19F,
+            UdsIdentifier::UdsVersionData => 0xFF00,
+            UdsIdentifier::ReservedForIso15765_5 => 0xFF01,
         }
     }
 }
 
-impl core::fmt::Display for UDSIdentifier {
+impl core::fmt::Display for UdsIdentifier {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let value: u16 = (*self).into();
         write!(f, "{value:#06X?}")
     }
 }
 
-impl core::fmt::Debug for UDSIdentifier {
+impl core::fmt::Debug for UdsIdentifier {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let value: u16 = (*self).into();
         write!(f, "{value:#06X}")
@@ -294,9 +294,9 @@ impl core::fmt::Debug for UDSIdentifier {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum UDSRoutineIdentifier {
+pub enum UdsRoutineIdentifier {
     /// ISO/SAE reserved routine identifier (`0x0000–0x00FF`, `0xE300–0xEFFF`, `0xFF02–0xFFFF`).
-    ISOSAEReserved(u16),
+    IsoSaeReserved(u16),
     /// Represent Tachograph test result values
     ///
     /// 0x0100-0x01FF
@@ -308,20 +308,20 @@ pub enum UDSRoutineIdentifier {
     VehicleManufacturerSpecific(u16),
 
     /// 0xE000-0xE1FF
-    OBDTestIds(u16),
+    ObdTestIds(u16),
 
     /// Execute Service Programming Loop (SPL)
     ///
     /// 0xE200
-    ExecuteSPL,
+    ExecuteSpl,
 
     /// Deploy Loop Routine ID
     ///
     /// 0xE201
-    DeployLoopRoutineID,
+    DeployLoopRoutineId,
 
     /// 0xE202-0xE2FF
-    SafetySystemRoutineID(u16),
+    SafetySystemRoutineId(u16),
 
     /// System Supplier Specific Routine Identifiers
     ///
@@ -339,17 +339,17 @@ pub enum UDSRoutineIdentifier {
     CheckProgrammingDependencies,
 }
 
-/// We know all values for the Routine Identifier, so we can implement `From<u16>` for `UDSRoutineIdentifier`
-impl From<u16> for UDSRoutineIdentifier {
+/// We know all values for the Routine Identifier, so we can implement `From<u16>` for `UdsRoutineIdentifier`
+impl From<u16> for UdsRoutineIdentifier {
     fn from(value: u16) -> Self {
         match value {
-            0x0000..=0x00FF | 0xE300..=0xEFFF | 0xFF02..=0xFFFF => Self::ISOSAEReserved(value),
+            0x0000..=0x00FF | 0xE300..=0xEFFF | 0xFF02..=0xFFFF => Self::IsoSaeReserved(value),
             0x0100..=0x01FF => Self::TachographTestIds(value),
             0x0200..=0xDFFF => Self::VehicleManufacturerSpecific(value),
-            0xE000..=0xE1FF => Self::OBDTestIds(value),
-            0xE200 => Self::ExecuteSPL,
-            0xE201 => Self::DeployLoopRoutineID,
-            0xE202..=0xE2FF => Self::SafetySystemRoutineID(value),
+            0xE000..=0xE1FF => Self::ObdTestIds(value),
+            0xE200 => Self::ExecuteSpl,
+            0xE201 => Self::DeployLoopRoutineId,
+            0xE202..=0xE2FF => Self::SafetySystemRoutineId(value),
             0xF000..=0xFEFF => Self::SystemSupplierSpecific(value),
             0xFF00 => Self::EraseMemory,
             0xFF01 => Self::CheckProgrammingDependencies,
@@ -357,20 +357,20 @@ impl From<u16> for UDSRoutineIdentifier {
     }
 }
 
-impl From<UDSRoutineIdentifier> for u16 {
+impl From<UdsRoutineIdentifier> for u16 {
     #[allow(clippy::match_same_arms)]
-    fn from(value: UDSRoutineIdentifier) -> Self {
+    fn from(value: UdsRoutineIdentifier) -> Self {
         match value {
-            UDSRoutineIdentifier::ISOSAEReserved(identifier) => identifier,
-            UDSRoutineIdentifier::TachographTestIds(identifier) => identifier,
-            UDSRoutineIdentifier::VehicleManufacturerSpecific(identifier) => identifier,
-            UDSRoutineIdentifier::OBDTestIds(identifier) => identifier,
-            UDSRoutineIdentifier::ExecuteSPL => 0xE200,
-            UDSRoutineIdentifier::DeployLoopRoutineID => 0xE201,
-            UDSRoutineIdentifier::SafetySystemRoutineID(identifier) => identifier,
-            UDSRoutineIdentifier::SystemSupplierSpecific(identifier) => identifier,
-            UDSRoutineIdentifier::EraseMemory => 0xFF00,
-            UDSRoutineIdentifier::CheckProgrammingDependencies => 0xFF01,
+            UdsRoutineIdentifier::IsoSaeReserved(identifier) => identifier,
+            UdsRoutineIdentifier::TachographTestIds(identifier) => identifier,
+            UdsRoutineIdentifier::VehicleManufacturerSpecific(identifier) => identifier,
+            UdsRoutineIdentifier::ObdTestIds(identifier) => identifier,
+            UdsRoutineIdentifier::ExecuteSpl => 0xE200,
+            UdsRoutineIdentifier::DeployLoopRoutineId => 0xE201,
+            UdsRoutineIdentifier::SafetySystemRoutineId(identifier) => identifier,
+            UdsRoutineIdentifier::SystemSupplierSpecific(identifier) => identifier,
+            UdsRoutineIdentifier::EraseMemory => 0xFF00,
+            UdsRoutineIdentifier::CheckProgrammingDependencies => 0xFF01,
         }
     }
 }
@@ -383,7 +383,7 @@ mod tests {
     fn uds_identifier_from_is_total_and_round_trips() {
         // Every u16 maps to a variant and round-trips back to itself.
         for raw in 0u16..=u16::MAX {
-            let id = UDSIdentifier::from(raw);
+            let id = UdsIdentifier::from(raw);
             assert_eq!(u16::from(id), raw, "round-trip failed for {raw:#06X}");
         }
     }
@@ -392,45 +392,45 @@ mod tests {
     fn uds_routine_identifier_from_is_total_and_round_trips() {
         // Every u16 maps to a variant and round-trips back to itself.
         for raw in 0u16..=u16::MAX {
-            let id = UDSRoutineIdentifier::from(raw);
+            let id = UdsRoutineIdentifier::from(raw);
             assert_eq!(u16::from(id), raw, "round-trip failed for {raw:#06X}");
         }
     }
 
     #[test]
     fn uds_identifier_classifies_representative_ranges() {
-        use UDSIdentifier::*;
+        use UdsIdentifier::*;
         assert!(matches!(
-            UDSIdentifier::from(0x0042),
-            ISOSAEReserved(0x0042)
+            UdsIdentifier::from(0x0042),
+            IsoSaeReserved(0x0042)
         ));
         assert!(matches!(
-            UDSIdentifier::from(0x2000),
+            UdsIdentifier::from(0x2000),
             VehicleManufacturerSpecific(0x2000)
         ));
         assert!(matches!(
-            UDSIdentifier::from(0xA600),
+            UdsIdentifier::from(0xA600),
             ReservedForLegislativeUse(0xA600)
         ));
         assert!(matches!(
-            UDSIdentifier::from(0xF100),
+            UdsIdentifier::from(0xF100),
             IdentificationOptionVehicleManufacturerSpecific(0xF100)
         ));
-        assert!(matches!(UDSIdentifier::from(0xF190), VIN));
+        assert!(matches!(UdsIdentifier::from(0xF190), Vin));
         assert!(matches!(
-            UDSIdentifier::from(0xF200),
+            UdsIdentifier::from(0xF200),
             PeriodicDataIdentifier(0xF200)
         ));
         assert!(matches!(
-            UDSIdentifier::from(0xF400),
-            OBDDataIdentifier(0xF400)
+            UdsIdentifier::from(0xF400),
+            ObdDataIdentifier(0xF400)
         ));
-        assert!(matches!(UDSIdentifier::from(0xFA10), NumberOfEDRDevices));
-        assert!(matches!(UDSIdentifier::from(0xFF00), UDSVersionData));
-        assert!(matches!(UDSIdentifier::from(0xFF01), ReservedForISO15765_5));
+        assert!(matches!(UdsIdentifier::from(0xFA10), NumberOfEdrDevices));
+        assert!(matches!(UdsIdentifier::from(0xFF00), UdsVersionData));
+        assert!(matches!(UdsIdentifier::from(0xFF01), ReservedForIso15765_5));
         assert!(matches!(
-            UDSIdentifier::from(0xFFFE),
-            ISOSAEReserved(0xFFFE)
+            UdsIdentifier::from(0xFFFE),
+            IsoSaeReserved(0xFFFE)
         ));
     }
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,5 +1,5 @@
 mod diagnostic_identifier;
-pub use diagnostic_identifier::{UDSIdentifier, UDSRoutineIdentifier};
+pub use diagnostic_identifier::{UdsIdentifier, UdsRoutineIdentifier};
 
 mod negative_response_code;
 pub use negative_response_code::NegativeResponseCode;

--- a/src/shared/negative_response_code.rs
+++ b/src/shared/negative_response_code.rs
@@ -10,7 +10,7 @@ pub enum NegativeResponseCode {
     PositiveResponse,
     /// This range of values is reserved for future definition.
     #[cfg_attr(feature = "clap", clap(skip))]
-    ISOSAEReserved(u8),
+    IsoSaeReserved(u8),
     /// This response code indicates that the requested action has been rejected by the server.
     /// The `GeneralReject` response code shall only be implemented in the server if none of the negative response codes meet the needs of the implementation.
     /// This response code shall not be used as a general replacement for other response codes defined.
@@ -91,9 +91,9 @@ pub enum NegativeResponseCode {
     /// therefore it is not listed in the list of applicable response codes of the diagnostic services.
     ServiceNotSupportedInActiveSession,
     /// This response code indicates that the requested action will not be taken because the server prerequisite condition for RPM is not met (current RPM is above a pre-programmed maximum threshold).
-    RPMTooHigh,
+    RpmTooHigh,
     /// This response code indicates that the requested action will not be taken because the server prerequisite condition for RPM is not met (current RPM is below a pre-programmed minimum threshold).
-    RPMTooLow,
+    RpmTooLow,
     /// This is required for those actuator tests which cannot be actuated while the Engine is running.
     /// This is different from RPM too high negative response and needs to be allowed.
     EngineIsRunning,
@@ -154,7 +154,7 @@ impl From<NegativeResponseCode> for u8 {
     fn from(value: NegativeResponseCode) -> Self {
         match value {
             NegativeResponseCode::PositiveResponse => 0x00,
-            NegativeResponseCode::ISOSAEReserved(value) => value,
+            NegativeResponseCode::IsoSaeReserved(value) => value,
             NegativeResponseCode::GeneralReject => 0x10,
             NegativeResponseCode::ServiceNotSupported => 0x11,
             NegativeResponseCode::SubFunctionNotSupported => 0x12,
@@ -177,8 +177,8 @@ impl From<NegativeResponseCode> for u8 {
             NegativeResponseCode::RequestCorrectlyReceivedResponsePending => 0x78,
             NegativeResponseCode::SubFunctionNotSupportedInActiveSession => 0x7E,
             NegativeResponseCode::ServiceNotSupportedInActiveSession => 0x7F,
-            NegativeResponseCode::RPMTooHigh => 0x81,
-            NegativeResponseCode::RPMTooLow => 0x82,
+            NegativeResponseCode::RpmTooHigh => 0x81,
+            NegativeResponseCode::RpmTooLow => 0x82,
             NegativeResponseCode::EngineIsRunning => 0x83,
             NegativeResponseCode::EngineIsNotRunning => 0x84,
             NegativeResponseCode::EngineRunTimeTooLow => 0x85,
@@ -205,39 +205,39 @@ impl From<u8> for NegativeResponseCode {
     fn from(value: u8) -> Self {
         match value {
             0x00 => Self::PositiveResponse,
-            0x01..=0x0F => Self::ISOSAEReserved(value),
+            0x01..=0x0F => Self::IsoSaeReserved(value),
             0x10 => Self::GeneralReject,
             0x11 => Self::ServiceNotSupported,
             0x12 => Self::SubFunctionNotSupported,
             0x13 => Self::IncorrectMessageLengthOrInvalidFormat,
             0x14 => Self::ResponseTooLong,
-            0x15..=0x20 => Self::ISOSAEReserved(value),
+            0x15..=0x20 => Self::IsoSaeReserved(value),
             0x21 => Self::BusyRepeatRequest,
             0x22 => Self::ConditionsNotCorrect,
-            0x23 => Self::ISOSAEReserved(value),
+            0x23 => Self::IsoSaeReserved(value),
             0x24 => Self::RequestSequenceError,
-            0x25..=0x30 => Self::ISOSAEReserved(value),
+            0x25..=0x30 => Self::IsoSaeReserved(value),
             0x31 => Self::RequestOutOfRange,
-            0x32 => Self::ISOSAEReserved(value),
+            0x32 => Self::IsoSaeReserved(value),
             0x33 => Self::SecurityAccessDenied,
             0x34 => Self::AuthenticationRequired,
             0x35 => Self::InvalidKey,
             0x36 => Self::ExceedNumberOfAttempts,
             0x37 => Self::RequiredTimeDelayNotExpired,
             0x38..=0x4F => Self::ExtendedDataLinkSecurityReserved(value),
-            0x50..=0x6F => Self::ISOSAEReserved(value),
+            0x50..=0x6F => Self::IsoSaeReserved(value),
             0x70 => Self::UploadDownloadNotAccepted,
             0x71 => Self::TransferDataSuspended,
             0x72 => Self::GeneralProgrammingFailure,
             0x73 => Self::WrongBlockSequenceCounter,
-            0x74..=0x77 => Self::ISOSAEReserved(value),
+            0x74..=0x77 => Self::IsoSaeReserved(value),
             0x78 => Self::RequestCorrectlyReceivedResponsePending,
-            0x79..=0x7D => Self::ISOSAEReserved(value),
+            0x79..=0x7D => Self::IsoSaeReserved(value),
             0x7E => Self::SubFunctionNotSupportedInActiveSession,
             0x7F => Self::ServiceNotSupportedInActiveSession,
-            0x80 => Self::ISOSAEReserved(value),
-            0x81 => Self::RPMTooHigh,
-            0x82 => Self::RPMTooLow,
+            0x80 => Self::IsoSaeReserved(value),
+            0x81 => Self::RpmTooHigh,
+            0x82 => Self::RpmTooLow,
             0x83 => Self::EngineIsRunning,
             0x84 => Self::EngineIsNotRunning,
             0x85 => Self::EngineRunTimeTooLow,
@@ -249,14 +249,14 @@ impl From<u8> for NegativeResponseCode {
             0x8B => Self::ThrottleOrPedalTooLow,
             0x8C => Self::TransmissionRangeNotInNeutral,
             0x8D => Self::TransmissionRangeNotInGear,
-            0x8E => Self::ISOSAEReserved(value),
+            0x8E => Self::IsoSaeReserved(value),
             0x8F => Self::BrakeSwitchNotClosed,
             0x90 => Self::ShifterLeverNotInPark,
             0x91 => Self::TorqueConverterClutchLocked,
             0x92 => Self::VoltageTooHigh,
             0x93 => Self::VoltageTooLow,
             0x94..=0xFE => Self::ReservedForSpecificConditionsNotMet(value),
-            0xFF => Self::ISOSAEReserved(value),
+            0xFF => Self::IsoSaeReserved(value),
         }
     }
 }


### PR DESCRIPTION
First of four follow-on branches splitting `api/consistency-pass-1` into reviewable units. This
one is naming and reachability only — **no behaviour changes**, which is the property to check when
reviewing it.

15 public renames, plus one type that becomes nameable from the crate root:

| before | after |
|---|---|
| `UDSIdentifier`, `UDSRoutineIdentifier` | `UdsIdentifier`, `UdsRoutineIdentifier` |
| `DTCRecord`, `DTCStatusMask`, `DTCSeverityMask`, `DTCFormatIdentifier` | `DtcRecord`, `DtcStatusMask`, `DtcSeverityMask`, `DtcFormatIdentifier` |
| `DTCExtDataRecordNumber`, `DTCSnapshotRecordNumber`, `DTCStoredDataRecordNumber` | `DtcExtDataRecordNumber`, `DtcSnapshotRecordNumber`, `DtcStoredDataRecordNumber` |
| `ReadDTCInfoRequest`, `ReadDTCInfoResponse`, `ReadDTCInfoSubFunction` | `ReadDtcInfoRequest`, `ReadDtcInfoResponse`, `ReadDtcInfoSubFunction` |
| `ControlDTCSettingsRequest`, `ControlDTCSettingsResponse` | `ControlDtcSettingRequest`, `ControlDtcSettingResponse` |
| `DtcSettings` | `DtcSettingType` |

## Commit Message Details

Three commits, in dependency order:

1. **`fix: make DTCFaultDetectionCounterRecord reachable from the crate root`** — net-negative
   surface. It re-exports the `Item` type of a public iterator (callers could iterate but not name
   it: `E0425`), and deletes four private type aliases (`DTCFaultDetectionCounter`,
   `MemorySelection`, `DTCReadinessGroupIdentifier`, `DTCStatusAvailabilityMask`) that were leaking
   unlinkable names into public signatures. In this branch because that alias removal is a naming
   problem, and because the casing pass's diff assumes it.
2. **`refactor!: give UdsServiceType symmetric SID conversion names`** — four methods used three
   different shapes; you could not derive the response name from the request name in either
   direction. Standardises on `sid` over `byte`, which was already the term used by
   `Request::Other { sid }` and `NegativeResponse::request_service_sid()`.
3. **`refactor!: apply C-CASE acronym convention to all type and variant names`** — 24 files. Rust
   API Guidelines C-CASE defers to RFC 430, which names this exact case: "acronyms and contractions
   of compound words count as one word: use `Uuid` rather than `UUID`". Before this the crate had
   both conventions — 13 `Dtc`-style identifiers against 93 ALLCAPS — colliding inside single call
   chains (`ReadDTCInfoResponse::DTCList` iterated by `DtcAndStatusIter`).

Two ISO-fidelity corrections ride along in (3), because it was already renaming those exact
identifiers:

- **`ControlDtcSettings` → `ControlDtcSetting`.** ISO 14229-1:2020 clause 10.8 spells service 0x85
  `ControlDTCSetting` — singular — in all 41 occurrences; there is not one plural instance. The
  module's own header comment already had it right, so the plural lived only in the type names.
- **`DtcSettings` → `DtcSettingType`.** Clause 10.8 names the sub-function parameter
  `DTCSettingType` in all 11 occurrences, and `DTCSettings` appears nowhere in the standard.

### Why the underscores look inconsistent

`SaeJ1939_73DtcFormat` sits four lines from `SaeJ2012DaDtcFormat00` in the same enum. That is
compiler-forced, not taste: `rustc` permits `_` in a camel-case identifier only between two digits,
so `SaeJ2012_DaDtcFormat00` and `DtcClass_0` both trip `non_camel_case_types` while
`SaeJ1939_73DtcFormat` and `Iso14229_1DtcFormat` pass. These names are the maximum ISO fidelity
reachable without re-adding an `allow`.

### One scope change from the original plan

The `DtcSeverityAndStatusIter` → `WwhObdDtcSeverityIter` rename was going to be here and **moved to
the wire-conformance branch instead**. It cannot be separated: the rename also renames that
iterator's tests, and those tests assert the partial-record and `size_hint` behaviour that the
iterator-hang fix introduces. Cherry-picked here alone, three tests fail and the branch would have
carried an `impl FusedIterator` that is a false claim until that fix lands — the iterator loops
forever on a partial record without it.

### `codecov/patch` fails, and it is telling the truth

69.26% of the diff is covered against an 80% target, while `codecov/project` **passes** at 81.89%
(+3.35%). A rename touches whatever lines the renamed code occupies, so on this branch the patch
number is a measurement of how well the *pre-existing* code is tested — not of anything this branch
introduced.

It found a real gap, so I fixed the worst of it rather than waving it away. `service.rs` — 27
services, four public SID conversion functions — had **zero tests** and 27.13% coverage, while this
branch renames all four functions. The added table-driven tests take it to **97.89%** and the crate
total from 79.19% to 81.89%, and they are mutation-verified.

Three files still drag the diff number down, and they are the same three the earlier review flagged
as under-tested:

| file | coverage |
|---|---|
| `services/read_dtc_information.rs` | 46.29% |
| `response.rs` | 56.42% |
| `request.rs` | 59.13% |

Closing those means testing frame dispatch and the 0x19 response variants, which is the explicit
job of the test-integrity commits later in this split. Doing it here would pull that work into a
rename PR. `main` is not branch-protected and `codecov/patch` is not a required check, so this is
informational — but flagging it rather than letting it look like noise.

## Issue URL

No linked issue — this is the first split of the `api/consistency-pass-1` work, tracked in that
branch rather than an issue. `pr-lint.yml` offers a **No Issue** label for this case, but the label
still does not exist in this repo (noted on #48). Point me at an issue if you would rather link one.

## Testing

This branch's claim is "no behaviour change", so the testing is aimed at that:

- **Full suite green on the branch in its own right**, not inherited from the larger branch:
  167 tests `--all-features` (164 lib + 3 doctests) and 146 `--no-default-features`, all passing.
- `cargo clippy --all-targets -D warnings -D clippy::pedantic` clean under `--all-features` and
  default features. Under `--no-default-features` it reports 22 warnings — **exactly the count
  `origin/main` reports**, so this branch neither fixes nor worsens them. They are cleaned up later
  in the split, in the test-integrity commit.
- `cargo fmt --all --check` clean; `cargo doc --no-deps --all-features` clean.
- The four cherry-pick conflicts were resolved by hand, each by taking the rename and dropping
  content belonging to a commit that is not on this branch (`#[non_exhaustive]` from the sealing
  commit, a `FusedIterator` impl and `size_hint` docs from the hang fix, and two exports for a
  service this branch does not add). Verified afterwards that none of that content leaked in:
  `FusedIterator` and `RequestUpload*` appear nowhere.
- Rebased and cherry-picked with `rerere` explicitly disabled. This repo has
  `rerere.enabled=true` and `rerere.autoupdate=true` with 43 cached resolutions from earlier
  history rewrites, and on a first attempt it silently auto-staged stale resolutions and dropped
  two non-empty commits — including the casing pass itself — while leaving the final tree and the
  whole test suite green. Commit subject lists were diffed against the source branch to confirm
  nothing went missing this time.
