### PR TITLE
fix(ci): let the coverage job run the property tests it was excluding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,15 +55,22 @@ jobs:
       # than being skipped with `alloc-feature: ''`. The crate core is
       # no_std + no-alloc; `alloc` only adds conveniences on top.
       #
-      # Partitioned by test name rather than by target kind. automotive_wire_codec
-      # splits on `kind(test)` because its property suites are integration tests;
-      # here they are `proptest!` blocks inside the lib, so a kind-based split
-      # puts them in the Unit Tests job and leaves the Property Tests job with
-      # nothing to run -- `cargo nextest` exits 4 on an empty selection, which is
-      # how the first attempt at this file failed CI. Selecting on the `prop_`
-      # prefix keeps each job's contents matching its name, and holds regardless
-      # of which target the property tests live in.
-      unit-test-filter: 'not test(~prop_)'
+      # The Unit Tests job runs everything, because it is the job that uploads
+      # coverage. automotive_wire_codec can afford a disjoint split -- its property
+      # suites are integration tests, so `kind(test)` cleanly separates them --
+      # but here the property tests are `proptest!` blocks inside the lib, and
+      # excluding them from the coverage job dropped
+      # shared/negative_response_code.rs from 64.6% to 8.0% line coverage and the
+      # total from 80.2% to 79.2%, because a proptest is the only thing that
+      # exercises that file. Coverage should describe the whole suite, so the
+      # split is overlapping rather than disjoint: Property Tests re-runs the four
+      # proptests under their own name for a readable signal, and costs 0.02s.
+      #
+      # Do not set this to a filter that can select nothing. `cargo nextest`
+      # exits 4 on an empty selection, which is how the first version of this file
+      # failed CI: `kind(test)` matched no tests, because `main` has no `tests/`
+      # directory yet.
+      unit-test-filter: 'all()'
       property-test-filter: 'test(~prop_)'
       # Comprehensive runs (nightly, merge queue, main) fuzz for 10 minutes.
       # Three targets: request decode, response decode, and round trip.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,8 @@
-# Coverage gates. Coverage is uploaded by the Unit Tests CI job, which for this
-# crate runs every test that is not a `prop_`-prefixed property test — so the
-# lib's unit tests plus any integration suites. The Property Tests job runs the
-# four proptest roundtrips and uploads results only, no coverage, so these
-# targets are calibrated to a report that excludes them.
+# Coverage gates. Coverage is uploaded by the Unit Tests CI job, which runs the
+# whole suite — so these targets describe every test the crate has. The Property
+# Tests job re-runs the `prop_`-prefixed subset under its own name and uploads
+# results only, no coverage; it is deliberately a subset rather than the other
+# half of a split, so that excluding it cannot silently understate coverage.
 coverage:
   status:
     # Overall coverage must not regress by more than 1% on a PR.


### PR DESCRIPTION
A defect in #48 that I introduced and then tripped over on the very next PR.

#48 split the suite with `unit-test-filter: 'not test(~prop_)'` and
`property-test-filter: 'test(~prop_)'`. The Unit Tests job is the one that uploads coverage, so
that made the four `proptest!` roundtrips invisible to Codecov — and a proptest is the only thing
that exercises `shared/negative_response_code.rs`.

## Commit Message Details

Measured with the same tool CI uses (`cargo llvm-cov nextest --profile ci`):

| | excluding proptests (what CI uploaded) | including proptests |
|---|---|---|
| `shared/negative_response_code.rs` | **7.96%** | 64.60% |
| TOTAL (regions) | 79.19% | 80.19% |

So that file read as 8% covered rather than 65%, and any PR touching those lines failed
`codecov/patch`'s "80% of changed lines" gate for a reason unrelated to the PR. #51, the first
branch out of the `api/consistency-pass-1` split, is a pure rename and failed exactly that way —
which is how this surfaced.

The Unit Tests job now runs `all()`. The split becomes **overlapping rather than disjoint**:
Property Tests re-runs the same four tests under their own name, which is a readable signal and
costs 0.02s. Coverage describes the whole suite again.

`automotive_wire_codec` can afford the disjoint split because its property suites are integration
tests, so `kind(test)` separates them without hiding anything from the coverage job. That does not
transfer to a crate whose property tests live in the lib — that is the part of #48 I got wrong.

Also leaves a note against re-narrowing either filter: `cargo nextest` exits 4 on an empty
selection, which is how the *first* version of #48 failed CI (`kind(test)` matched nothing, because
`main` has no `tests/` directory yet). Both failure modes now have a comment next to the setting
that causes them.

## Issue URL

No linked issue — follow-up to #48. The **No Issue** label `pr-lint.yml` offers still does not exist
in this repo; worth creating so the intended path works.

## Testing

- Reproduced the cause with `cargo llvm-cov nextest --all-features --profile ci` twice against
  `main`'s tree, once with `-E 'not test(~prop_)'` and once unfiltered, to get the numbers above.
  The fix is derived from that measurement rather than from reasoning about the config.
- Verified both filters behave against `main`'s tree: `all()` runs 160 tests, `test(~prop_)` runs 4.
- Both changed YAML files parse.
- The real check is CI on this PR: `codecov/project` and `codecov/patch` should pass, and the
  Property Tests job should report 4 tests rather than 0 or an error.
