### PR TITLE
refactor!: encapsulation, serde validation, and the churn-audit corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -333,3 +333,5 @@ omniscient.toml
 .superpowers/
 
 omniscient.toml
+
+docs/superpowers/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,13 @@ repos:
     rev: 0.7.22
     hooks:
     - id: mdformat
+      # README.md is this crate's front page *and* its crate-level rustdoc, via
+      # `#![doc = include_str!(".../README.md")]`. mdformat escapes `[` and `]`, which
+      # turns every rustdoc intra-doc link in it into literal text: measured on the
+      # generated HTML, escaping drops the links to `Request`, `Response` and
+      # `UdsServiceType` from 3/3/2 to 1/1/1. Formatting prose is not worth silently
+      # breaking the published documentation.
+      exclude: ^README\.md$
       language_version: python3
       additional_dependencies:
           - linkify-it-py==1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -534,6 +534,10 @@ made the two gaps above possible.
   `DtcStatusMask` with its "bits on = supported by server" semantics moved onto the four
   `status_availability_mask` fields. This closes the `TODO` above sub-function `0x18`.
 
+- `RequestTransferExitRequest` and `RequestTransferExitResponse` now derive `serde` and
+  `utoipa` support like every other public request/response type. Enabling the `serde` feature
+  previously left these two types unserializable.
+
 ### Removed
 
 - The `serde_bytes` optional dependency. The `serde` feature activated it, but the crate never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,75 @@ standard's own numbered example tables, which is what closes that gap.
 - **Breaking:** `UdsServiceType::DynamicallyDefinedDataIdentifier` is now
   `DynamicallyDefineDataIdentifier`, the name Table 23 gives service 0x2C.
 
+### Fixed — API shape
+
+- **Breaking:** `From<u32> for DtcRecord` is now `TryFrom<u32>`. It masked the top byte away, so
+  `from(0x01_0203)` and `from(0xFF01_0203)` compared equal — a caller with a DTC one byte too wide
+  got a wrong DTC and no signal. New `Error::InvalidDtcRecord`.
+
+- **Breaking:** `RequestDownloadResponse::new` / `RequestUploadResponse::new` are fallible and
+  `max_number_of_block_length` is behind an accessor. Its length becomes a single nibble, so it
+  cannot exceed 15 bytes — a check that lived in `encode`, leaving a 16-byte slice constructible
+  and only then unencodable, reachable through the public field as well.
+
+- **Breaking:** `LengthFormatIdentifier` no longer zeroes the low nibble of the
+  `lengthFormatIdentifier`, which ISO 14229-1 leaves undefined: `74 25 08 00` used to re-encode as
+  `74 20 08 00`. Same reasoning as the earlier `TesterPresentRequest` fix. Its property test had
+  generated `high_nibble << 4`, so the low nibble was always zero and the property held trivially.
+
+- **Breaking:** `NamePayload` no longer carries `mode_of_operation` — that is the
+  `RequestFileTransferRequest` variant, and nothing kept the two in step. The field won, so
+  `AddFile(NamePayload::new(DeleteFile, ..), dfi, size)` encoded a DeleteFile request and dropped
+  the format identifier and both sizes. New `RequestFileTransferRequest::mode_of_operation()`.
+
+- **Breaking:** `DtcStoredDataRecordNumber::new` is total, matching both sibling record-number
+  types, and gains `is_reserved()` plus the `PartialEq<u8>` they already had. It returned `Result`
+  while `From<u8>` accepted anything, so the invariant it advertised was not one the type held.
+
+- **Breaking:** four `Error` variants that no code path could construct are gone —
+  `NoDataAvailable`, `InvalidFileSizeParameterLength`, `InvalidDtcFormatIdentifier` and
+  `ReservedForLegislativeUse`. All were in the NRC mapping and asserted by its test, so the suite
+  was green on unreachable states.
+
+- **Breaking:** `#[non_exhaustive]` now covers the byte-carrying reserved variants of
+  `DtcFormatIdentifier`, `FunctionalGroupIdentifier`, `FileOperationMode` and
+  `ReadDtcInfoSubFunction`, matching the four sub-function enums that already had it. Naming one
+  directly let a caller build a value that aliases a named variant — `IsoSaeReserved(0x01)` is not
+  equal to `Iso14229_1DtcFormat` but encodes the same byte, so `PartialEq` silently stopped meaning
+  wire equality.
+
+- **Breaking:** `fault_detection_iter` is `dtc_fault_detection_iter`, matching
+  `DtcFaultDetectionIter`; and `clap::Parser` is gone from `UdsIdentifier`, where it had made a
+  53-variant data enum into a CLI parser with a `parse()` that reads `std::env::args`.
+
+- `Request` and `Response` derive `Eq`/`PartialEq`; every payload type already did, so `assert_eq!`
+  worked on a payload but not on the frame holding it.
+
+- Byte extraction is now `const` on the five types that had only a non-const `From`
+  (`NegativeResponseCode`, `DtcFormatIdentifier`, `FileOperationMode`, `DataFormatIdentifier`,
+  `CommunicationControlType`, plus `DtcRecord::to_u32`). A `const` server dispatch table could be
+  built but not read. Adding `CommunicationControlType::value()` also makes
+  `CommunicationControlRequest::new` and `::new_with_node_id` `const` — all 47 constructors now are.
+
+### Fixed — test integrity
+
+Mutation testing over the suite found 11 of 23 mutants surviving. The gaps, now closed: no test
+had ever asserted a value the DTC iterators yield, or any of the four header fields of the 0x42
+response; `allowed_nack_codes` dispatch asserted only `!is_empty()`, so any of 16 arms could return
+another service's table; the misaligned-record-list test never covered a list shorter than one
+record, the boundary it exists for; the iterator-termination test drained unbounded, so a
+regression hung `cargo test` rather than failing it; and six "round-trip" tests encoded into a
+buffer they never read.
+
+Ten codec tests were gated on `alloc` only because they used `Vec` as a writer. With stack buffers
+the no_std configuration — the one the crate targets first — now runs 236 tests rather than 186,
+and `clippy --no-default-features --all-targets` went from 21 warnings to zero.
+
+`assert_encode_size_agrees`' doc comment now says what it does not prove: `encoded_size` counts by
+encoding into a sink, so every quantity it compares comes from `encode` itself and none of them
+constrain *which* bytes are written. Reading its call sites as byte-correctness coverage is what
+made the two gaps above possible.
+
 ### Fixed — documentation
 
 - `NegativeResponseCode::RequestCorrectlyReceivedResponsePending` (0x78) carried 0x73's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
 Found by a review pass that checked the crate against the ISO 14229-1:2020 text rather than
 against itself. All five predate this branch; none was caught by the existing tests, because a
 round-trip written against the crate's own output passes whenever `encode` and `decode` share a
-misreading. `tests/spec_conformance.rs` now round-trips 34 byte sequences quoted from the
-standard's own numbered example tables, which is what closes that gap.
+misreading. `tests/spec_conformance.rs` now round-trips 36 byte sequences quoted from the
+standard's own numbered example tables. That catches a legal frame the crate rejects, and an
+`encode`/`decode` pair that disagree with each other — but not a misreading the two share
+symmetrically, which still round-trips. See the module doc for where the line falls.
 
 - **Breaking:** `MemoryFormatIdentifier::try_from` used exclusive range patterns where its own
   comments said inclusive, accepting a `memorySize` width of 1-3 and a `memoryAddress` width of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ standard's own numbered example tables, which is what closes that gap.
   Table 36 defines that as `0xFF`.
 
 - **Breaking:** `ReadDtcInfoRequest` gained `suppress_positive_response`. `decode` matched the raw
-  sub-function byte, so bit 7 — SPRMIB — was read as part of the sub-function value. Table 13
+  sub-function byte, so bit 7 — SPRMIB — was read as part of the sub-function value. Table 11
   requires both bit values for every supported sub-function. A suppressed
   `reportDTCByStatusMask` (`19 82 FF`) was rejected as having trailing bytes, and `19 8A` decoded
   as a *reserved* sub-function, so a server answered `SubFunctionNotSupported` to a request it was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,10 +94,28 @@ symmetrically, which still round-trips. See the module doc for where the line fa
   Table 484 mandates. 0x24 exists specifically for `ResumeFile` against an already-complete
   transfer.
 
-- `RequestDownloadRequest::new_with_widths` / `RequestUploadRequest::new_with_widths` let a client
-  choose the field widths. Table 441 makes the `addressAndLengthFormatIdentifier` a client choice,
-  not a function of the values, and `new` derives only minimal widths — so the crate could not
-  reproduce Table 462's own example, nor satisfy the bootloaders that mandate a fixed ALFID.
+- **Breaking:** `AddressAndLengthFormatIdentifier` is public, and
+  `RequestDownloadRequest::new_with_alfid` / `RequestUploadRequest::new_with_alfid` take one. Table
+  441 makes the `addressAndLengthFormatIdentifier` a client choice, not a function of the values,
+  and `new` derives only minimal widths — so the crate could not reproduce Table 462's own example
+  (three `memorySize` bytes for `0x00FFFF`), nor satisfy a bootloader that mandates a fixed ALFID.
+
+  A bootloader states that requirement as a byte, so the type is built from one:
+  `AddressAndLengthFormatIdentifier::try_from(0x44)?`. That replaces a five-parameter
+  `new_with_widths(dfi, address, address_len, size, size_len)` whose four numeric arguments
+  included two transposable width/value pairs, with no compiler help — the nibbles are
+  asymmetric (high is size, low is address), so a swap silently truncated.
+
+  `new` now derives its widths and **delegates** to `new_with_alfid`. The two used to be
+  independent code paths that disagreed: the same over-wide `memory_address` produced
+  `InvalidMemoryAddress` from one and `IncorrectMessageLengthOrInvalidFormat` from the other, so
+  one input yielded NRC `0x31` or `0x13` depending on which constructor a caller reached for.
+  Nothing tested it. New `Error::InvalidMemorySize` completes the pair, and both map to `0x31` as
+  Tables 444 and 449 require for a `memoryAddress`/`memorySize` that "is not valid".
+
+  This also changes the `serde` shape of both requests: the widths were two derived scalars
+  (`memory_address_length`, `memory_size_length`) and are now the single ISO-named
+  `address_and_length_format_identifier` byte, matching Table 441 rather than paraphrasing it.
 
 ### Fixed — encapsulation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,6 +481,14 @@ made the two gaps above possible.
   `--no-default-features --features alloc` combinations were ever built, so the optional
   integrations were never exercised in isolation.
 
+- **Breaking:** `utoipa` additionally implies `serde`. A `ToSchema` in this crate describes the
+  *`serde`* representation — several types serialize as a single protocol byte rather than as
+  their Rust shape, and their schemas are hand-written to match — so a `utoipa`-without-`serde`
+  build published a schema for a wire format it could not produce. Supporting that combination
+  also meant every type reachable only through a `serde` repr needed a second `cfg` predicate and
+  an `allow(dead_code)` to stay compilable in a configuration no one wants. The feature powerset
+  is 16 combinations rather than 20 as a result, all clean.
+
 - The `serde` feature now works on a bare-metal target. The dependency was declared with
   serde's default features on, which pulls `serde/std`, so
   `cargo build --no-default-features --features serde --target thumbv6m-none-eabi` failed even

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,141 @@ pre-1.0 crates).
 
 These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
 
+### Fixed — wire-format conformance
+
+Found by a review pass that checked the crate against the ISO 14229-1:2020 text rather than
+against itself. All five predate this branch; none was caught by the existing tests, because a
+round-trip written against the crate's own output passes whenever `encode` and `decode` share a
+misreading. `tests/spec_conformance.rs` now round-trips 34 byte sequences quoted from the
+standard's own numbered example tables, which is what closes that gap.
+
+- **Breaking:** `MemoryFormatIdentifier::try_from` used exclusive range patterns where its own
+  comments said inclusive, accepting a `memorySize` width of 1-3 and a `memoryAddress` width of
+  1-4. Annex H Table H.1 runs to 4 and 5, and `RequestDownloadRequest::new` already documented and
+  derived those wider values — so the crate emitted frames it could not decode. Any transfer above
+  16 MB, or to an address above 4 GB, was unrepresentable, and ALFID `0x44` (the usual value in a
+  real programming session) was rejected outright. The property test had its generators narrowed
+  to exactly the buggy accepted set.
+
+- **Breaking:** `EcuResetResponse::power_down_time` is now `Option<u8>`. Table 35 marks
+  `powerDownTime` `Cvt` = `C`, present only for `enableRapidPowerShutDown`, and Table 39's flow
+  example is the two-byte `51 01`. The field was a bare `u8` that `encode` always wrote, so
+  decoding `51 01` and re-encoding produced `51 01 00`: any proxy that decoded and re-encoded
+  traffic rewrote every positive response except 0x04's. `None` is now distinct from `Some(0)`,
+  which the old decode conflated, and the doc named `0x00` as the not-available sentinel where
+  Table 36 defines that as `0xFF`.
+
+- **Breaking:** `ReadDtcInfoRequest` gained `suppress_positive_response`. `decode` matched the raw
+  sub-function byte, so bit 7 — SPRMIB — was read as part of the sub-function value. Table 13
+  requires both bit values for every supported sub-function. A suppressed
+  `reportDTCByStatusMask` (`19 82 FF`) was rejected as having trailing bytes, and `19 8A` decoded
+  as a *reserved* sub-function, so a server answered `SubFunctionNotSupported` to a request it was
+  required to execute. 0x19 was the only one of the eight sub-function services not using the
+  shared helper.
+
+- **Breaking:** `ReadDtcInfoSubFunction::ReportUserDefMemoryDtcByStatusMask` gained the mandatory
+  `MemorySelection` byte (Table 310). The conformant 4-byte request was rejected and the malformed
+  3-byte one accepted — exactly inverted. Sub-functions 0x18 and 0x19 already read theirs.
+
+- **Breaking:** `ReadDtcInfoResponse::NumberOfDtcs` gained `format_identifier`. Table 319 makes
+  `DTCFormatIdentifier` mandatory between the availability mask and the count, so decode was
+  reading it as the count's high byte: Table 341's own example `59 01 2F 01 00 01` was rejected
+  outright, and a count of 1 came back as `0x0100`. It is also the only thing that says how to
+  interpret a DTC's three bytes.
+
+### Fixed — spec gaps in modeled services
+
+- **Breaking:** `ControlDtcSettingRequest` gained `option_record: &'d [u8]` for the
+  `DTCSettingControlOptionRecord` (Table 127, `Cvt` = `U`), so the type now borrows. Table 132
+  reserves NRC `0x31` for an error *in that record*, which a server can only detect if the record
+  reaches it. This is the same `Cvt = U` omission as `ClearDiagnosticInformation`'s
+  `memorySelection`.
+
+- **Breaking:** `DtcSettingType` gained `VehicleManufacturerSpecific` and `SystemSupplierSpecific`
+  for the `0x40`-`0x5F` and `0x60`-`0x7E` ranges Table 128 reserves. Both were rejected outright,
+  so a client could not send a manufacturer-defined setting and a server never saw the byte.
+
+- **Breaking:** `CommunicationControl` now decodes the subnet nibble. Annex B Table B.1 splits
+  the `communicationType` byte into message type (bits 1-0), reserved bits 3-2 and subnet number
+  (bits 7-4), but the whole byte was matched against `0x00..=0x03`, so `0xF3` — a common
+  real-world value — was rejected. New `SubnetNumber` type, plus
+  `CommunicationControlRequest::with_subnet` and `::subnet`. The file's `TODO` admitting this gap
+  is gone.
+
+- **Breaking:** `RoutineControlSubFunction::try_from` returns
+  `Error::InvalidRoutineControlSubFunction` rather than `IncorrectMessageLengthOrInvalidFormat`,
+  so a reserved `routineControlType` is answered with NRC `0x12` as Table 430 requires rather than
+  `0x13` — for a request whose length was perfectly correct. That variant had never been
+  constructed anywhere in the crate despite being in the NRC mapping table and its test.
+
+- **Breaking:** `WriteDataByIdentifierRequest::new` is now fallible and `decode` requires three
+  payload bytes. Table 277 marks `dataRecord` byte #1 mandatory and Figure 26 states a four-byte
+  minimum, but a three-byte message decoded into an empty data record, so a server would attempt
+  a zero-length write instead of answering NRC `0x13`. A test had locked the wrong behaviour in.
+
+- **Breaking:** `DtcStoredDataRecordNumber::new` no longer rejects `0xF0`. Clause 12.3.3.2
+  reserves only `0x00` for this parameter; `0x00`/`0xF0` is the *snapshot* record-number space,
+  and both the check and its doc had been copied from there.
+
+- `RequestFileTransferRequest::allowed_nack_codes` gained `RequestSequenceError` (0x24),
+  `SecurityAccessDenied` (0x33) and `AuthenticationRequired` (0x34), three of the seven codes
+  Table 484 mandates. 0x24 exists specifically for `ResumeFile` against an already-complete
+  transfer.
+
+- `RequestDownloadRequest::new_with_widths` / `RequestUploadRequest::new_with_widths` let a client
+  choose the field widths. Table 441 makes the `addressAndLengthFormatIdentifier` a client choice,
+  not a function of the values, and `new` derives only minimal widths — so the crate could not
+  reproduce Table 462's own example, nor satisfy the bootloaders that mandate a fixed ALFID.
+
+### Fixed — encapsulation
+
+- **Breaking:** deserializing can no longer bypass a type's validation. `derive(Deserialize)`
+  ignores both field visibility and constructor checks, so it was a second, unchecked way in for
+  every sealed type: `serde_json::from_str::<SecurityAccessLevel>("255")` succeeded, producing a
+  level that encoded to a byte which decoded back as a *different* level with SPRMIB set. The six
+  single-byte types now serialize as their wire byte via `serde(try_from = "u8", into = "u8")`,
+  and `TesterPresentRequest`, `CommunicationControlRequest` and the two transfer requests
+  deserialize through a repr routed via their constructors. This changes their serialized
+  representation, and removes the module-private `ZeroSubFunction` and the `pub(crate)`
+  `MemoryFormatIdentifier` from both the serialized form and the generated OpenAPI schema, where
+  they had been giving client generators types downstream Rust cannot name.
+
+- `DtcFaultDetectionCounterRecord::new`. The type is `#[non_exhaustive]` with `pub` fields and had
+  no `impl` block, so outside the crate a struct literal is `E0639` and there was no constructor
+  to fall back on — the `Item` type of a public iterator was unbuildable by any downstream crate.
+  Introduced on this branch by the `#[non_exhaustive]` sweep; the test meant to guard it was a
+  unit test, where the attribute does not apply.
+
+- **Breaking:** `UdsServiceType::DynamicallyDefinedDataIdentifier` is now
+  `DynamicallyDefineDataIdentifier`, the name Table 23 gives service 0x2C.
+
+### Fixed — documentation
+
+- `NegativeResponseCode::RequestCorrectlyReceivedResponsePending` (0x78) carried 0x73's
+  description, calling it a `BlockSequenceCounter` error. It is the response-pending code that
+  extends P2\*, and per Annex A.1 obliges the server to send a final response regardless of
+  SPRMIB.
+
+- `DiagnosticSessionControlResponse::p2_star_server_max` documented its scaling backwards. Table
+  29 gives the parameter a 10 ms resolution, so the stored value is milliseconds ÷ 10; reading it
+  as a raw millisecond count under-waits by a factor of ten.
+
+- `ReadDtcInfoResponse`'s `InsufficientData` shortfalls measured `needed` including the
+  sub-function byte while `available` was measured after it, so `needed - available` overstated
+  the gap by one.
+
+- `RoutineControlResponse::status_record` now says that it spans the optional `routineInfo` byte
+  as well (Table 428). Nothing on the wire distinguishes the two layouts, so a general-purpose
+  decoder cannot split them — but the field name implied it already had.
+
+- `ReadDtcInfoSubFunction::IsoSaeReserved` listed `0x42` — a modeled report type — as reserved,
+  and omitted most of the ranges Table 317 actually reserves.
+
+- README: `AccessTimingParameters` is annotated as ISO 14229-1:2013-only (it was removed in the
+  2020 edition the crate targets), the escaped brackets that rendered as dead `[Request]` text on
+  the crate's front page are now real links, and the re-export list no longer says the codec
+  traits are re-exported "eventually" — they already are.
+
 ### Added
 
 - `NegativeResponse::new_with_sid(request_service_sid, nrc)`, the construction-side counterpart
@@ -40,7 +175,7 @@ These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
   every server had to re-derive the mapping against a `#[non_exhaustive]` enum.
 
 - `Request::allowed_nack_codes()` dispatches to the per-service tables from a decoded
-  `Request`, alongside the existing `service()` and `is_positive_response_suppressed()`. All 15
+  `Request`, alongside the existing `service()` and `is_positive_response_suppressed()`. All 16
   request types already exposed the associated function, but reaching it from a `Request`
   required matching every variant. Returns an empty slice for `Request::Other`, meaning "NRC set
   unknown" rather than "no codes apply".
@@ -58,8 +193,9 @@ These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
 
 - `DtcRecord::high_byte()`, `middle_byte()` and `low_byte()`. The fields are private and the type
   had no accessors at all, so a decoded DTC could only be inspected by round-tripping through
-  `u32` — awkward given ISO 14229-1 Annex D.1 assigns the high byte its own meaning (system
-  group). All three are `const fn`.
+  `u32`. All three are `const fn`. Their docs deliberately do not ascribe a meaning to any
+  individual byte: ISO 14229-1 clause 12.3.2.3 specifies no decoding method for the three DTC
+  bytes, deferring to whichever standard the `DTCFormatIdentifier` names.
 
 ### Changed
 
@@ -73,13 +209,13 @@ These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
   decode with `InsufficientData`, while every encode emitted a spurious 4th byte.
 
 - **Breaking:** `SecurityAccessLevel::value` now takes `&self` instead of `self`, matching the
-  other twenty accessors in the crate. No call-site change is needed: the type is `Copy`.
+  crate's other by-reference accessors. No call-site change is needed: the type is `Copy`.
 
 - `DtcRecord::new`, `DtcSnapshotRecordNumber::new`, `DtcExtDataRecordNumber::new`,
   `DtcStoredDataRecordNumber::new`, `DataFormatIdentifier::new`, `NegativeResponse::new`,
   `NegativeResponse::request_service`, `RequestDownloadRequest::new`, `RequestUploadRequest::new`
   and all four `UdsServiceType` SID conversions (`from_request_sid`, `to_request_sid`,
-  `from_response_sid`, `to_response_sid`) are now `const fn`. The crate was otherwise uniformly
+  `from_response_sid`, `to_response_sid`) are now `const fn`. Most of the crate was already
   `const fn new`, and the gaps fell exactly on the primitives a caller wants in a `const` table:
   DTC constants, record numbers, the format identifier, and the SID map a server dispatch table
   is built from. `NegativeResponse::new` was blocked only because `to_request_sid` was not const.
@@ -141,8 +277,8 @@ These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
   | `ReadDTCInfoSubFunction`         | `ReadDtcInfoSubFunction`         |
 
   Enum variants follow the same rule mechanically (`UdsServiceType::ReadDTCInfo` ->
-  `ReadDtcInfo`, `ISOSAEReserved` -> `IsoSaeReserved` across all nine enums that
-  declare it, and so on). Four variant groups did **not** rename mechanically:
+  `ReadDtcInfo`, `ISOSAEReserved` -> `IsoSaeReserved` across every enum that declares it, and
+  so on). Four variant groups did **not** rename mechanically:
 
   - `ReadDtcInfoSubFunction` variants lose their underscores along with the enum's
     `#[allow(non_camel_case_types)]`: `ReportDTC_ByStatusMask` -> `ReportDtcByStatusMask`,
@@ -173,6 +309,17 @@ These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
   Both `to_*` methods now document the lossy `0x7F` fallback for
   `NegativeResponse`/`UnsupportedDiagnosticService`, and point at `Request::Other` /
   `Response::Other` for lossless pass-through of unmodeled services.
+
+- **Breaking:** `#[non_exhaustive]` added to eleven public types that ISO will grow into, so
+  that later additions are not breaking changes: `ReadDtcInfoSubFunction`, `FileOperationMode`,
+  `DtcExtDataRecordNumber`, `DtcSnapshotRecordNumber`, `DtcFaultDetectionCounterRecord`,
+  `SizePayload`, `NamePayload`, `SentDataPayload`, `FileSizePayload`, `DirSizePayload`,
+  `PositionPayload`. Downstream `match` statements over these need a wildcard arm, and the
+  seven structs must be built through `new()` rather than a struct literal — which is why
+  `DtcFaultDetectionCounterRecord` gained one (see below); it had no constructor at all, so this
+  attribute had made it impossible for a downstream crate to build.
+  `ReadDtcInfoSubFunction` is the important one: it has sub-functions the crate does not model
+  yet, so adding one post-tag would otherwise have been breaking.
 
 - **Breaking:** `Error::InsufficientData` now carries an `automotive_wire_codec::Incomplete`
   (with `needed` and `available` byte counts) instead of a bare `usize`.
@@ -247,10 +394,12 @@ These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
   keeps its signature and its `0x00` encoding — so a server can report
   `subFunctionNotSupported` naming the byte it actually received.
 
-- `TesterPresentResponse::new()` is now `const`, the last `new()` in the crate that was not.
+- `TesterPresentResponse::new()` is now `const`. `CommunicationControlRequest::new` and
+  `::new_with_node_id` remain non-`const`: both call `u8::from` on the control type in their
+  error path, and trait methods are not callable in a `const fn` on stable.
 
-- The README service table was missing rows for `DynamicallyDefinedDataIdentifier` (0x2C) and
-  `AccessTimingParameter` (0x83), both enumerated in `UdsServiceType`, and named two services
+- The README service table was missing rows for `DynamicallyDefineDataIdentifier` (0x2C) and
+  `AccessTimingParameters` (0x83), both enumerated in `UdsServiceType`, and named two services
   differently from the code (`ECUReset`, `ControlDTCSetting`). The table's 27 rows now match the
   27 request SIDs in `UdsServiceType` exactly.
 
@@ -271,8 +420,9 @@ These changes require at least a 0.1.0 -> 0.2.0 bump before the next release.
   features are enabled.
 
 - `FunctionalGroupIdentifier::VODBSystem` is now `VobdSystem`. Beyond the casing change, the
-  old name transposed the letters: ISO 14229-1 Table D.1 names functional group `0xFE`
-  `VOBDSystem` (vehicle OBD system).
+  old name transposed the letters: ISO 14229-1 Table **D.15** names functional group `0xFE`
+  `VOBDsystem` (vehicle OBD system). Table D.1 is the `groupOfDTC` definition, not the
+  functional-group one.
 
 - `DtcFaultDetectionCounterRecord` is now exported from the crate root. It is the `Item` of
   the public `DtcFaultDetectionIter`, but had no public path, so callers could iterate it and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "embedded-io",
  "proptest",
  "serde",
+ "serde_json",
  "thiserror",
  "utoipa",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,5 @@ clap = { version = "4", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 proptest = "1"
+# Only used by the integration tests that check `serde` cannot bypass a type's validation.
+serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,14 @@ alloc = ["embedded-io/alloc", "serde?/alloc"]
 serde = ["dep:serde"]
 # `utoipa` and `clap` both imply `std`. Their derive macros expand to `std::`, `String` and
 # `Vec` paths inside this crate, which cannot compile under `#![no_std]`.
-utoipa = ["std", "dep:utoipa"]
+#
+# `utoipa` additionally implies `serde`, because a `ToSchema` describes this crate's *serde*
+# representation: several types serialize as a single protocol byte rather than as their Rust
+# shape, and their schemas are written to match. A `utoipa`-without-`serde` build would therefore
+# publish a schema for a wire format that build cannot produce. It also cost real complexity —
+# every type reachable only through a serde repr needed a second cfg predicate and a
+# `allow(dead_code)` to stay compilable in a configuration nobody wants.
+utoipa = ["std", "serde", "dep:utoipa"]
 clap = ["std", "dep:clap"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This crate offers an ergonomic, `no_std`-friendly implementation of the UDS (ISO 14229) protocol codec in Rust.
 It targets embedded ECU diagnostics and desktop tooling alike: encoding and decoding UDS protocol messages — and custom data types — with no required allocator and no async runtime.
-It is not in a complete state yet with the 0.1.0 release, please check back soon!
+It is not in a complete state yet, please check back soon!
 
 [![Crates.io](https://img.shields.io/crates/v/uds_protocol.svg?style=for-the-badge)](https://crates.io/crates/uds_protocol)
 [![Docs.rs](https://img.shields.io/docsrs/uds_protocol?style=for-the-badge)](https://docs.rs/uds_protocol)
@@ -26,7 +26,7 @@ It is based on the ISO 14229-1:2020 standard.
 | `CommunicationControl`             | 0x28        | 0x68         | ✓       |
 | `Authentication`                   | 0x29        | 0x69         |         |
 | `ReadDataByPeriodicIdentifier`     | 0x2A        | 0x6A         |         |
-| `DynamicallyDefinedDataIdentifier` | 0x2C        | 0x6C         |         |
+| `DynamicallyDefineDataIdentifier`  | 0x2C        | 0x6C         |         |
 | `WriteDataByIdentifier`            | 0x2E        | 0x6E         | ✓       |
 | `InputOutputControlByIdentifier`   | 0x2F        | 0x6F         |         |
 | `RoutineControl`                   | 0x31        | 0x71         | ✓       |
@@ -37,11 +37,15 @@ It is based on the ISO 14229-1:2020 standard.
 | `RequestFileTransfer`              | 0x38        | 0x78         | ✓       |
 | `WriteMemoryByAddress`             | 0x3D        | 0x7D         |         |
 | `TesterPresent`                    | 0x3E        | 0x7E         | ✓       |
-| `AccessTimingParameter`            | 0x83        | 0xC3         |         |
+| `AccessTimingParameters`[^1]       | 0x83        | 0xC3         |         |
 | `SecuredDataTransmission`          | 0x84        | 0xC4         |         |
 | `ControlDtcSetting`                | 0x85        | 0xC5         | ✓       |
 | `ResponseOnEvent`                  | 0x86        | 0xC6         |         |
 | `LinkControl`                      | 0x87        | 0xC7         |         |
+
+[^1]: `AccessTimingParameters` (0x83) was defined in ISO 14229-1:2013 and removed in the 2020
+edition. `UdsServiceType` still names it so a 2013-era service byte round-trips rather than
+becoming an unrecognized `Other`, but it is not part of the standard this crate targets.
 
 ## Integration
 
@@ -82,22 +86,22 @@ you need to keep before the buffer is reused.
 
 ## Service coverage
 
-These services decode into typed \[`Request`\]/\[`Response`\] variants: `DiagnosticSessionControl`,
+These services decode into typed [`Request`]/[`Response`] variants: `DiagnosticSessionControl`,
 `EcuReset`, `SecurityAccess`, `CommunicationControl`, `TesterPresent`, `ControlDtcSetting`,
 `ReadDataByIdentifier`, `WriteDataByIdentifier`, `ClearDiagnosticInfo`, `ReadDtcInfo`,
 `RoutineControl`, `RequestDownload`, `RequestUpload`, `TransferData`, `RequestTransferExit`,
 `RequestFileTransfer`, and `NegativeResponse`.
 
-All other services enumerated in \[`UdsServiceType`\] (e.g. `Authentication`, `ReadMemoryByAddress`,
+All other services enumerated in [`UdsServiceType`] (e.g. `Authentication`, `ReadMemoryByAddress`,
 `ResponseOnEvent`) are not individually modeled. Frames for them decode into
-\[`Request::Other`\] / \[`Response::Other`\], carrying the service type and raw payload bytes for
+[`Request::Other`] / [`Response::Other`], carrying the service type and raw payload bytes for
 pass-through.
 
 ## Wire codec dependency
 
 `uds_protocol` builds its byte-level decoding on top of the [`automotive-wire-codec`](https://crates.io/crates/automotive-wire-codec)
-crate, and re-exports its `Incomplete` and `TrailingBytes` types (and, eventually, its codec
-traits) at the crate root. These types are intentionally part of `uds_protocol`'s public API:
+crate, and re-exports its `Incomplete`, `TrailingBytes` and `InvalidWidth` types and its codec
+traits (`Encode`, `Decode`, `DecodeIter`) at the crate root. These types are intentionally part of `uds_protocol`'s public API:
 they are shared across the Luminar automotive protocol crates so that callers handling multiple
 protocols see one consistent short-read/trailing-data error shape. Because of this, a semver-major
 release of `automotive-wire-codec` is a breaking change for `uds_protocol` as well.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,33 @@ It is based on the ISO 14229-1:2020 standard.
 edition. `UdsServiceType` still names it so a 2013-era service byte round-trips rather than
 becoming an unrecognized `Other`, but it is not part of the standard this crate targets.
 
+## Features
+
+Default is `std`. The crate is `no_std` and allocation-free at its core; everything below is
+additive.
+
+| Feature | Implies | What it gives you |
+|---------|---------|-------------------|
+| `std` *(default)* | `alloc` | `std::error::Error` for [`Error`], and `embedded_io`'s `std` layer. Turn it off for bare metal. |
+| `alloc` | — | The `alloc`-only conveniences. Nothing in the wire codec needs it; encoding and decoding work with borrowed slices alone. |
+| `serde` | — | `Serialize`/`Deserialize` on the request, response and parameter types. The only optional integration usable on a bare-metal target: it is wired as a core-only dependency and picks up serde's `alloc`/`std` layers only when this crate's own are on. |
+| `utoipa` | `std`, `serde` | `ToSchema` for `OpenAPI` generation. |
+| `clap` | `std` | `ValueEnum` on the sub-function enums, for building a CLI tester. |
+
+Two implications are worth knowing about:
+
+- **`utoipa` implies `serde`** because a `ToSchema` here describes the *`serde`* representation.
+  Several types serialize as a single protocol byte rather than as their Rust shape — a
+  `DataFormatIdentifier` is `33`, not `{"compression_method":2,"encryption_method":1}` — and the
+  schemas are written to match. Without `serde` the schema would describe a wire format that
+  build cannot produce.
+- **`utoipa` and `clap` imply `std`** because their derive macros expand to `std::`, `String` and
+  `Vec` paths inside this crate, which cannot compile under `#![no_std]`.
+
+With `serde` enabled, the types that carry a range invariant deserialize through the same
+classifier the wire decoder uses, so a hand-written payload cannot construct a value that would
+encode to an illegal byte.
+
 ## Integration
 
 `uds_protocol` is a synchronous, allocation-free codec. It owns no sockets, buffers, or

--- a/src/dtc/ext_data.rs
+++ b/src/dtc/ext_data.rs
@@ -6,6 +6,7 @@ use automotive_wire_codec::write_u8;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DtcExtDataRecordNumber {
     /// ISO/SAE reserved record numbers (`0x00`, `0xF0-0xFD`).
     IsoSaeReserved(u8),

--- a/src/dtc/snapshot.rs
+++ b/src/dtc/snapshot.rs
@@ -9,6 +9,7 @@ use automotive_wire_codec::write_u8;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DtcSnapshotRecordNumber {
     /// Reserved for Legislative purposes
     Reserved(u8),

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -170,6 +170,23 @@ impl From<u8> for DtcFormatIdentifier {
     }
 }
 
+impl DtcFormatIdentifier {
+    /// The raw format-identifier byte.
+    ///
+    /// `const`, unlike `u8::from(identifier)`, so a `const` table can read it back out.
+    #[must_use]
+    pub const fn value(&self) -> u8 {
+        match self {
+            Self::SaeJ2012DaDtcFormat00 => 0x00,
+            Self::Iso14229_1DtcFormat => 0x01,
+            Self::SaeJ1939_73DtcFormat => 0x02,
+            Self::Iso11992_4DtcFormat => 0x03,
+            Self::SaeJ2012DaDtcFormat04 => 0x04,
+            Self::IsoSaeReserved(value) => *value,
+        }
+    }
+}
+
 impl From<DtcFormatIdentifier> for u8 {
     fn from(val: DtcFormatIdentifier) -> Self {
         match val {
@@ -269,6 +286,17 @@ impl TryFrom<u32> for DtcRecord {
             middle_byte: ((value >> 8) & 0xFF) as u8,
             low_byte: (value & 0xFF) as u8,
         })
+    }
+}
+
+impl DtcRecord {
+    /// The three DTC bytes as the low 24 bits of a `u32`, big-endian.
+    ///
+    /// `const`, unlike `u32::from(record)`: trait methods are not callable in a `const fn` on
+    /// stable, so a `const` table of DTC values needs this.
+    #[must_use]
+    pub const fn to_u32(&self) -> u32 {
+        ((self.high_byte as u32) << 16) | ((self.middle_byte as u32) << 8) | self.low_byte as u32
     }
 }
 

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -154,6 +154,7 @@ pub enum DtcFormatIdentifier {
 
     /// Reserved for future usage
     /// 0x05 - 0xFF
+    #[non_exhaustive]
     IsoSaeReserved(u8),
 }
 
@@ -364,6 +365,7 @@ pub enum FunctionalGroupIdentifier {
     /// 0x34 to 0xCF
     /// 0xE0 to 0xFD
     /// 0xFF
+    #[non_exhaustive]
     IsoSaeReserved(u8),
     /// 0x33
     EmissionsSystemGroup,

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -241,7 +241,7 @@ impl DtcRecord {
     /// to this byte in isolation — and its powertrain/chassis/body/network rows are explicitly
     /// "to be determined by vehicle manufacturer". The one byte-level assignment it makes is to
     /// the *low* byte: for `0xFFFF00`-`0xFFFFFE` that byte is a
-    /// [`FunctionalGroupIdentifier`](crate::FunctionalGroupIdentifier).
+    /// [`FunctionalGroupIdentifier`].
     #[must_use]
     pub const fn high_byte(&self) -> u8 {
         self.high_byte
@@ -258,7 +258,7 @@ impl DtcRecord {
     ///
     /// In SAE J2012-DA format this is the failure type byte, and for a `groupOfDTC` in
     /// `0xFFFF00`-`0xFFFFFE` it is a
-    /// [`FunctionalGroupIdentifier`](crate::FunctionalGroupIdentifier) (ISO 14229-1:2020 Annex
+    /// [`FunctionalGroupIdentifier`] (ISO 14229-1:2020 Annex
     /// D.1 Table D.1). Neither reading is universal — see [`high_byte`](Self::high_byte).
     #[must_use]
     pub const fn low_byte(&self) -> u8 {

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -212,20 +212,36 @@ impl DtcRecord {
         }
     }
 
-    /// The high byte, which ISO 14229-1 Annex D.1 uses to identify the system group
-    /// (powertrain, body, chassis, network).
+    /// The most significant of the three DTC bytes.
+    ///
+    /// What it means depends on the server's [`DtcFormatIdentifier`]: ISO 14229-1 itself
+    /// specifies no decoding method for the three bytes (clause 12.3.2.3), deferring to
+    /// whichever of SAE J2012-DA, ISO 11992-4, SAE J1939-73 or ISO 15031-6 the format
+    /// identifier names.
+    ///
+    /// Annex D.1 Table D.1 does assign meaning, but to whole 3-byte `groupOfDTC` *values*, not
+    /// to this byte in isolation — and its powertrain/chassis/body/network rows are explicitly
+    /// "to be determined by vehicle manufacturer". The one byte-level assignment it makes is to
+    /// the *low* byte: for `0xFFFF00`-`0xFFFFFE` that byte is a
+    /// [`FunctionalGroupIdentifier`](crate::FunctionalGroupIdentifier).
     #[must_use]
     pub const fn high_byte(&self) -> u8 {
         self.high_byte
     }
 
-    /// The middle byte of the DTC number.
+    /// The middle of the three DTC bytes. See [`high_byte`](Self::high_byte) for why this
+    /// crate does not ascribe a meaning to it.
     #[must_use]
     pub const fn middle_byte(&self) -> u8 {
         self.middle_byte
     }
 
-    /// The low byte of the DTC number, which carries the failure type.
+    /// The least significant of the three DTC bytes.
+    ///
+    /// In SAE J2012-DA format this is the failure type byte, and for a `groupOfDTC` in
+    /// `0xFFFF00`-`0xFFFFFE` it is a
+    /// [`FunctionalGroupIdentifier`](crate::FunctionalGroupIdentifier) (ISO 14229-1:2020 Annex
+    /// D.1 Table D.1). Neither reading is universal — see [`high_byte`](Self::high_byte).
     #[must_use]
     pub const fn low_byte(&self) -> u8 {
         self.low_byte
@@ -459,13 +475,19 @@ impl<'a> Decode<'a> for DtcSeverityMask {
 pub struct DtcStoredDataRecordNumber(u8);
 
 impl DtcStoredDataRecordNumber {
-    /// Create a `DtcStoredDataRecordNumber` from a raw byte, rejecting the values ISO 14229-1
-    /// reserves.
+    /// Create a `DtcStoredDataRecordNumber` from a raw byte, rejecting the one value ISO 14229-1
+    /// reserves for this parameter.
+    ///
+    /// Clause 12.3.3.2 reserves `0x00` for legislated purposes, makes `0x01`-`0xFE` available
+    /// for vehicle-manufacturer use, and gives `0xFF` the meaning "report all stored records".
+    /// Note that `0xF0` is *not* reserved here — that belongs to the
+    /// [`DtcSnapshotRecordNumber`](crate::DtcSnapshotRecordNumber) space, which the spec says
+    /// does not share an address space with this one.
     ///
     /// # Errors
-    /// Returns [`Error::ReservedForLegislativeUse`] if the record number is `0x00` or `0xF0`.
+    /// Returns [`Error::ReservedForLegislativeUse`] if the record number is `0x00`.
     pub const fn new(record_number: u8) -> Result<Self, Error> {
-        if record_number == 0 || record_number == 0xF0 {
+        if record_number == 0 {
             return Err(Error::ReservedForLegislativeUse(record_number));
         }
         Ok(Self(record_number))
@@ -473,9 +495,9 @@ impl DtcStoredDataRecordNumber {
 
     /// Return the raw record-number byte.
     ///
-    /// A value obtained from [`From<u8>`](Self::from) or [`Decode`] may be a reserved
-    /// `0x00`/`0xF0` that [`new`](Self::new) would reject — decoding is deliberately liberal
-    /// so responses from foreign implementations can still be inspected.
+    /// A value obtained from [`From<u8>`](Self::from) or [`Decode`] may be the reserved `0x00`
+    /// that [`new`](Self::new) would reject — decoding is deliberately liberal so responses
+    /// from foreign implementations can still be inspected.
     #[must_use]
     pub const fn value(&self) -> u8 {
         self.0
@@ -527,15 +549,24 @@ mod encode_param_tests {
 
     #[test]
     fn stored_data_record_number_construction_is_strict_parsing_is_liberal() {
-        // TX: constructing a reserved value is rejected.
+        // ISO 14229-1:2020 clause 12.3.3.2 reserves only 0x00 for this parameter: "DTCStoredData
+        // records in range of 0x01 through 0xFE shall be available for vehicle manufacturer
+        // specific usage", and 0xFF requests all records.
         assert!(matches!(
-            DtcStoredDataRecordNumber::new(0xF0),
-            Err(Error::ReservedForLegislativeUse(0xF0))
+            DtcStoredDataRecordNumber::new(0x00),
+            Err(Error::ReservedForLegislativeUse(0x00))
         ));
+
+        // 0xF0 belongs to the *snapshot* record-number space, not this one, and used to be
+        // rejected here by a doc-and-check copied from `DtcSnapshotRecordNumber`.
+        assert_eq!(DtcStoredDataRecordNumber::new(0xF0).unwrap().value(), 0xF0);
+        assert_eq!(DtcStoredDataRecordNumber::new(0xFE).unwrap().value(), 0xFE);
+        assert_eq!(DtcStoredDataRecordNumber::new(0xFF).unwrap().value(), 0xFF);
+
         // RX: a reserved value from a foreign implementation still decodes, and value()
         // lets the caller inspect it.
-        let (decoded, _) = <DtcStoredDataRecordNumber as Decode>::decode(&[0xF0]).unwrap();
-        assert_eq!(decoded.value(), 0xF0);
+        let (decoded, _) = <DtcStoredDataRecordNumber as Decode>::decode(&[0x00]).unwrap();
+        assert_eq!(decoded.value(), 0x00);
     }
 
     #[test]

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -248,13 +248,27 @@ impl DtcRecord {
     }
 }
 
-impl From<u32> for DtcRecord {
-    fn from(value: u32) -> Self {
-        Self {
+impl TryFrom<u32> for DtcRecord {
+    type Error = Error;
+
+    /// A DTC is three bytes, so only the low 24 bits of a `u32` are a valid DTC.
+    ///
+    /// This is `TryFrom` rather than `From` because masking the top byte away silently would
+    /// make `0xFF01_0203` and `0x0001_0203` the same record — a caller who has a DTC in a `u32`
+    /// from elsewhere and one byte too many would get a wrong DTC with no signal.
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidDtcRecord`] if `value` exceeds `0x00FF_FFFF`.
+    fn try_from(value: u32) -> Result<Self, Error> {
+        if value > 0x00FF_FFFF {
+            return Err(Error::InvalidDtcRecord(value));
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(Self {
             high_byte: ((value >> 16) & 0xFF) as u8,
             middle_byte: ((value >> 8) & 0xFF) as u8,
             low_byte: (value & 0xFF) as u8,
-        }
+        })
     }
 }
 
@@ -607,7 +621,7 @@ mod dtc_status_tests {
     fn dtc_record_exposes_its_three_wire_bytes() {
         // A decoded DtcRecord has to be inspectable byte-wise: D.1 assigns meaning to the
         // high byte (system group) separately from the middle and low bytes.
-        let record = DtcRecord::from(0x12_3456);
+        let record = DtcRecord::try_from(0x12_3456).unwrap();
         assert_eq!(record.high_byte(), 0x12);
         assert_eq!(record.middle_byte(), 0x34);
         assert_eq!(record.low_byte(), 0x56);

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -517,32 +517,43 @@ impl<'a> Decode<'a> for DtcSeverityMask {
 pub struct DtcStoredDataRecordNumber(u8);
 
 impl DtcStoredDataRecordNumber {
-    /// Create a `DtcStoredDataRecordNumber` from a raw byte, rejecting the one value ISO 14229-1
-    /// reserves for this parameter.
+    /// Create a `DtcStoredDataRecordNumber` from a raw byte. Every byte is accepted.
+    ///
+    /// Total, like [`DtcSnapshotRecordNumber::new`](crate::DtcSnapshotRecordNumber::new) and
+    /// [`DtcExtDataRecordNumber::new`](crate::DtcExtDataRecordNumber::new), because decoding is
+    /// deliberately liberal and `From<u8>` already accepted anything — so a fallible `new`
+    /// promised a guarantee the type did not actually hold. Use
+    /// [`is_reserved`](Self::is_reserved) when you need the check.
     ///
     /// Clause 12.3.3.2 reserves `0x00` for legislated purposes, makes `0x01`-`0xFE` available
     /// for vehicle-manufacturer use, and gives `0xFF` the meaning "report all stored records".
     /// Note that `0xF0` is *not* reserved here — that belongs to the
     /// [`DtcSnapshotRecordNumber`](crate::DtcSnapshotRecordNumber) space, which the spec says
     /// does not share an address space with this one.
-    ///
-    /// # Errors
-    /// Returns [`Error::ReservedForLegislativeUse`] if the record number is `0x00`.
-    pub const fn new(record_number: u8) -> Result<Self, Error> {
-        if record_number == 0 {
-            return Err(Error::ReservedForLegislativeUse(record_number));
-        }
-        Ok(Self(record_number))
+    #[must_use]
+    pub const fn new(record_number: u8) -> Self {
+        Self(record_number)
+    }
+
+    /// Whether this record number is the `0x00` that clause 12.3.3.2 reserves for legislated
+    /// purposes, and which a client therefore should not request.
+    #[must_use]
+    pub const fn is_reserved(&self) -> bool {
+        self.0 == 0
     }
 
     /// Return the raw record-number byte.
     ///
-    /// A value obtained from [`From<u8>`](Self::from) or [`Decode`] may be the reserved `0x00`
-    /// that [`new`](Self::new) would reject — decoding is deliberately liberal so responses
-    /// from foreign implementations can still be inspected.
+    /// May be the reserved `0x00`; check [`is_reserved`](Self::is_reserved) if that matters.
     #[must_use]
     pub const fn value(&self) -> u8 {
         self.0
+    }
+}
+
+impl PartialEq<u8> for DtcStoredDataRecordNumber {
+    fn eq(&self, other: &u8) -> bool {
+        self.value() == *other
     }
 }
 
@@ -581,7 +592,7 @@ mod encode_param_tests {
 
     #[test]
     fn encode_stored_data_record_number() {
-        let n = DtcStoredDataRecordNumber::new(0x05).unwrap();
+        let n = DtcStoredDataRecordNumber::new(0x05);
         let mut buf = [0u8; 4];
         let written = Encode::encode(&n, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(written, 1);
@@ -590,25 +601,23 @@ mod encode_param_tests {
     }
 
     #[test]
-    fn stored_data_record_number_construction_is_strict_parsing_is_liberal() {
+    fn stored_data_record_number_accepts_every_byte_and_flags_the_reserved_one() {
         // ISO 14229-1:2020 clause 12.3.3.2 reserves only 0x00 for this parameter: "DTCStoredData
         // records in range of 0x01 through 0xFE shall be available for vehicle manufacturer
-        // specific usage", and 0xFF requests all records.
-        assert!(matches!(
-            DtcStoredDataRecordNumber::new(0x00),
-            Err(Error::ReservedForLegislativeUse(0x00))
-        ));
+        // specific usage", and 0xFF requests all records. 0xF0 belongs to the *snapshot*
+        // record-number space and used to be rejected here by a check copied from there.
+        for byte in [0x00u8, 0x01, 0xF0, 0xFE, 0xFF] {
+            let number = DtcStoredDataRecordNumber::new(byte);
+            assert_eq!(number.value(), byte);
+            assert_eq!(number, byte, "PartialEq<u8> must agree with value()");
+            assert_eq!(number, DtcStoredDataRecordNumber::from(byte));
+            assert_eq!(number.is_reserved(), byte == 0x00, "for {byte:#04X}");
+        }
 
-        // 0xF0 belongs to the *snapshot* record-number space, not this one, and used to be
-        // rejected here by a doc-and-check copied from `DtcSnapshotRecordNumber`.
-        assert_eq!(DtcStoredDataRecordNumber::new(0xF0).unwrap().value(), 0xF0);
-        assert_eq!(DtcStoredDataRecordNumber::new(0xFE).unwrap().value(), 0xFE);
-        assert_eq!(DtcStoredDataRecordNumber::new(0xFF).unwrap().value(), 0xFF);
-
-        // RX: a reserved value from a foreign implementation still decodes, and value()
-        // lets the caller inspect it.
+        // Decoding is liberal for the same reason `new` is total: a response from a foreign
+        // implementation must still be inspectable.
         let (decoded, _) = <DtcStoredDataRecordNumber as Decode>::decode(&[0x00]).unwrap();
-        assert_eq!(decoded.value(), 0x00);
+        assert!(decoded.is_reserved());
     }
 
     #[test]

--- a/src/dtc/status.rs
+++ b/src/dtc/status.rs
@@ -132,7 +132,7 @@ impl<'a> Decode<'a> for DtcStatusMask {
 ///
 /// A given server shall only support one `DtcFormatIdentifier`.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "serde", serde(from = "u8", into = "u8"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 #[repr(u8)]
@@ -154,7 +154,6 @@ pub enum DtcFormatIdentifier {
 
     /// Reserved for future usage
     /// 0x05 - 0xFF
-    #[non_exhaustive]
     IsoSaeReserved(u8),
 }
 
@@ -185,6 +184,15 @@ impl DtcFormatIdentifier {
             Self::SaeJ2012DaDtcFormat04 => 0x04,
             Self::IsoSaeReserved(value) => *value,
         }
+    }
+}
+
+impl PartialEq<u8> for DtcFormatIdentifier {
+    /// Wire equality: compares the byte this identifier encodes to. Variant equality is not the
+    /// same thing -- `IsoSaeReserved(0x01)` and `Iso14229_1DtcFormat` both encode `0x01` but are
+    /// different variants, so use this when the wire byte is what matters.
+    fn eq(&self, other: &u8) -> bool {
+        self.value() == *other
     }
 }
 
@@ -357,7 +365,7 @@ impl<'a> DecodeIter<'a> for DtcRecord {
 ///     * Requesting DTC status from a vehicle
 ///     * Clearing DTC information in the vehicle
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "serde", serde(from = "u8", into = "u8"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum FunctionalGroupIdentifier {
@@ -365,7 +373,6 @@ pub enum FunctionalGroupIdentifier {
     /// 0x34 to 0xCF
     /// 0xE0 to 0xFD
     /// 0xFF
-    #[non_exhaustive]
     IsoSaeReserved(u8),
     /// 0x33
     EmissionsSystemGroup,
@@ -403,6 +410,15 @@ impl From<u8> for FunctionalGroupIdentifier {
             0xD1..=0xDF => FunctionalGroupIdentifier::LegislativeSystemGroup(value),
             _ => FunctionalGroupIdentifier::IsoSaeReserved(value),
         }
+    }
+}
+
+impl PartialEq<u8> for FunctionalGroupIdentifier {
+    /// Wire equality: compares the byte this identifier encodes to. `LegislativeSystemGroup`
+    /// and `IsoSaeReserved` can carry the same byte as a named variant, so variant equality is
+    /// not wire equality.
+    fn eq(&self, other: &u8) -> bool {
+        u8::from(*self) == *other
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,13 @@ pub enum Error {
     /// The memory address value is out of the valid range.
     #[error("Invalid Memory Address: {0}")]
     InvalidMemoryAddress(u64),
+    /// The memory size does not fit the width the `addressAndLengthFormatIdentifier` declares
+    /// for it, so encoding it would truncate the value on the wire.
+    ///
+    /// Tables 444 and 449 put a `memorySize` that "is not valid" on NRC 0x31, like
+    /// [`Error::InvalidMemoryAddress`].
+    #[error("Invalid Memory Size: {0}")]
+    InvalidMemorySize(u32),
     /// The `addressAndLengthFormatIdentifier` byte declares a width ISO does not permit.
     ///
     /// ISO 14229-1:2020 Annex H Table H.1 marks the high nibble (`memorySize`) applicable for
@@ -170,6 +177,7 @@ impl Error {
             // A parameter value is outside its permitted range.
             Self::InvalidCommunicationType(_)
             | Self::InvalidMemoryAddress(_)
+            | Self::InvalidMemorySize(_)
             | Self::InvalidAddressAndLengthFormatIdentifier(_)
             | Self::InvalidDtcRecord(_)
             | Self::InvalidEncryptionCompressionMethod(_)
@@ -325,6 +333,11 @@ mod nrc_mapping_tests {
                 Error::InvalidAddressAndLengthFormatIdentifier(0x00),
                 0x31,
                 "addressAndLengthFormatIdentifier outside Table H.1",
+            ),
+            (
+                Error::InvalidMemorySize(0x1_0000),
+                0x31,
+                "memorySize wider than its declared width",
             ),
         ]
         .into_iter()

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,10 +100,9 @@ impl Error {
     /// use uds_protocol::{Decode, NegativeResponse, Request, UdsServiceType};
     ///
     /// let frame = [0x11, 0x01, 0xAA]; // EcuReset with a trailing junk byte
-    /// if let Err(err) = Request::decode(&frame) {
-    ///     let nack = NegativeResponse::new(UdsServiceType::EcuReset, err.negative_response_code());
-    ///     assert_eq!(u8::from(nack.nrc()), 0x13);
-    /// }
+    /// let err = Request::decode(&frame).expect_err("the trailing byte must be rejected");
+    /// let nack = NegativeResponse::new(UdsServiceType::EcuReset, err.negative_response_code());
+    /// assert_eq!(u8::from(nack.nrc()), 0x13);
     /// ```
     ///
     /// # Classification

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,9 +71,6 @@ pub enum Error {
     /// The DTC-setting byte is not a valid [`DtcSettingType`](crate::DtcSettingType) value.
     #[error("Invalid DTC Setting: {0}")]
     InvalidDtcSetting(u8),
-    /// The value is reserved for legislative use and must not be used.
-    #[error("Reserved for legislative use: {0}")]
-    ReservedForLegislativeUse(u8),
 }
 
 impl Error {
@@ -153,8 +150,7 @@ impl Error {
             | Self::InvalidMemoryAddress(_)
             | Self::InvalidDtcRecord(_)
             | Self::InvalidEncryptionCompressionMethod(_)
-            | Self::InvalidFileOperationMode(_)
-            | Self::ReservedForLegislativeUse(_) => NegativeResponseCode::RequestOutOfRange,
+            | Self::InvalidFileOperationMode(_) => NegativeResponseCode::RequestOutOfRange,
 
             // Transport failure: not a protocol error, so no specific NRC applies.
             Self::IoError(_) => NegativeResponseCode::GeneralReject,
@@ -299,11 +295,6 @@ mod nrc_mapping_tests {
                 Error::InvalidDtcRecord(0xFF01_0203),
                 0x31,
                 "a u32 wider than three DTC bytes",
-            ),
-            (
-                Error::ReservedForLegislativeUse(0x99),
-                0x31,
-                "legislative reserved value",
             ),
             // --- 0x10 generalReject: transport failure, no protocol NRC applies ---
             (

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,24 +53,18 @@ pub enum Error {
     /// The memory address value is out of the valid range.
     #[error("Invalid Memory Address: {0}")]
     InvalidMemoryAddress(u64),
+    /// A `u32` did not fit the three bytes of a DTC (i.e. exceeded `0x00FF_FFFF`).
+    #[error("Invalid DTC record: {0:#010X} does not fit three bytes")]
+    InvalidDtcRecord(u32),
     /// The encryption or compression method byte is not recognised.
     #[error("Invalid Encryption/Compression Method: {0}")]
     InvalidEncryptionCompressionMethod(u8),
-    /// A payload was expected but the stream contained no data.
-    #[error("Data required but found none")]
-    NoDataAvailable,
     /// The `RequestFileTransfer` `modeOfOperation` byte is not valid.
     #[error("Invalid FileTransfer modeOfOperation (server will send requestOutOfRange): {0}")]
     InvalidFileOperationMode(u8),
-    /// The `fileSizeParameterLength` / `fileSizeOrDirInfoParameterLength` value is outside 1–16.
-    #[error("Invalid fileSizeParameterLength (valid range: 1..=16): {0}")]
-    InvalidFileSizeParameterLength(u16),
     /// The `ReadDTCInformation` sub-function byte is not valid.
     #[error("Invalid DTC Subfunction Type: {0}")]
     InvalidDtcSubfunctionType(u8),
-    /// The DTC format identifier byte is not recognised.
-    #[error("Invalid DTC Format Identifier: {0}")]
-    InvalidDtcFormatIdentifier(u8),
     /// The routine-control sub-function byte is not a valid [`RoutineControlSubFunction`](crate::RoutineControlSubFunction).
     #[error("Invalid Routine Control Sub-Function: {0}")]
     InvalidRoutineControlSubFunction(u8),
@@ -112,8 +106,18 @@ impl Error {
     /// - **`0x13` `incorrectMessageLengthOrInvalidFormat`** — the frame itself is malformed:
     ///   too short, too long, or a declared width that does not fit.
     /// - **`0x12` `subFunctionNotSupported`** — the *sub-function* byte is not a value this
-    ///   service defines. Applies to the services whose sub-function the crate validates:
-    ///   `0x10`, `0x11`, `0x19`, `0x27`, `0x28`, `0x31`, `0x3E`, `0x85`.
+    ///   service defines.
+    ///
+    ///   Only two services reject a reserved sub-function at decode and so produce this code
+    ///   themselves: `0x31` `RoutineControl` (Table 426 defines no manufacturer range, so
+    ///   anything outside `0x01`-`0x03` is invalid) and `0x85` `ControlDTCSetting`.
+    ///
+    ///   The others — `0x10`, `0x11`, `0x19`, `0x27`, `0x28`, `0x3E` — model the whole
+    ///   `0x00..=0x7F` space, so a reserved byte decodes into an `IsoSaeReserved`-style variant
+    ///   and round-trips unchanged rather than failing. That is deliberate: it lets a server see
+    ///   the byte it was actually sent. **Answering `0x12` for those is the server's job**, not
+    ///   this mapping's: match on the sub-function and use
+    ///   [`NegativeResponseCode::SubFunctionNotSupported`] for a value you do not implement.
     /// - **`0x31` `requestOutOfRange`** — a *parameter* (not a sub-function) carries a value
     ///   outside its permitted range. Note that `communicationType` is a parameter of
     ///   `CommunicationControl`, not its sub-function, so it lands here rather than on `0x12`.
@@ -130,8 +134,9 @@ impl Error {
             Self::InsufficientData(_)
             | Self::TrailingBytes(_)
             | Self::InvalidWidth(_)
-            | Self::IncorrectMessageLengthOrInvalidFormat
-            | Self::NoDataAvailable => NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
+            | Self::IncorrectMessageLengthOrInvalidFormat => {
+                NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat
+            }
 
             // The sub-function byte is not a defined value for the service.
             Self::InvalidDiagnosticSessionType(_)
@@ -146,10 +151,9 @@ impl Error {
             // A parameter value is outside its permitted range.
             Self::InvalidCommunicationType(_)
             | Self::InvalidMemoryAddress(_)
+            | Self::InvalidDtcRecord(_)
             | Self::InvalidEncryptionCompressionMethod(_)
             | Self::InvalidFileOperationMode(_)
-            | Self::InvalidFileSizeParameterLength(_)
-            | Self::InvalidDtcFormatIdentifier(_)
             | Self::ReservedForLegislativeUse(_) => NegativeResponseCode::RequestOutOfRange,
 
             // Transport failure: not a protocol error, so no specific NRC applies.
@@ -237,11 +241,6 @@ mod nrc_mapping_tests {
                 0x13,
                 "explicit length/format",
             ),
-            (
-                Error::NoDataAvailable,
-                0x13,
-                "payload expected, none present",
-            ),
             // --- 0x12 subFunctionNotSupported: the sub-function byte is not a known value ---
             (
                 Error::InvalidDiagnosticSessionType(0x99),
@@ -297,14 +296,9 @@ mod nrc_mapping_tests {
                 "0x38 modeOfOperation",
             ),
             (
-                Error::InvalidFileSizeParameterLength(0x99),
+                Error::InvalidDtcRecord(0xFF01_0203),
                 0x31,
-                "0x38 length parameter",
-            ),
-            (
-                Error::InvalidDtcFormatIdentifier(0x99),
-                0x31,
-                "DTC format identifier",
+                "a u32 wider than three DTC bytes",
             ),
             (
                 Error::ReservedForLegislativeUse(0x99),

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,13 @@ pub enum Error {
     /// The memory address value is out of the valid range.
     #[error("Invalid Memory Address: {0}")]
     InvalidMemoryAddress(u64),
+    /// The `addressAndLengthFormatIdentifier` byte declares a width ISO does not permit.
+    ///
+    /// ISO 14229-1:2020 Annex H Table H.1 marks the high nibble (`memorySize`) applicable for
+    /// 1 to 4 bytes and the low nibble (`memoryAddress`) for 1 to 5; a zero nibble or anything
+    /// wider is "not applicable". Tables 444 and 449 both put this on NRC 0x31, not 0x13.
+    #[error("Invalid addressAndLengthFormatIdentifier: {0:#04X}")]
+    InvalidAddressAndLengthFormatIdentifier(u8),
     /// A `u32` did not fit the three bytes of a DTC (i.e. exceeded `0x00FF_FFFF`).
     #[error("Invalid DTC record: {0:#010X} does not fit three bytes")]
     InvalidDtcRecord(u32),
@@ -92,13 +99,21 @@ impl Error {
     ///
     /// let frame = [0x11, 0x01, 0xAA]; // EcuReset with a trailing junk byte
     /// let err = Request::decode(&frame).expect_err("the trailing byte must be rejected");
-    /// let nack = NegativeResponse::new(UdsServiceType::EcuReset, err.negative_response_code());
+    /// let nrc = err.negative_response_code().expect("a malformed frame maps to an NRC");
+    /// let nack = NegativeResponse::new(UdsServiceType::EcuReset, nrc);
     /// assert_eq!(u8::from(nack.nrc()), 0x13);
     /// ```
     ///
+    /// Returns `None` for [`Error::IoError`]: a transport failure is not a protocol error, so
+    /// there is no NRC to send. Every other error maps to a code.
+    ///
     /// # Classification
     ///
-    /// Following ISO 14229-1:
+    /// This is a **default**, covering the lane ISO 14229-1 actually mandates — clause 8.7.5's
+    /// pseudo-code and the "shall" rows of Annex A.1. Clause 8.7.2 notes that "a specific NRC
+    /// is not guaranteed for all possible test pattern sequences", and several outcomes in
+    /// Tables 4 to 7 are specified only as "NRC = XX", so a server is free to answer
+    /// differently where its own tables allow:
     ///
     /// - **`0x13` `incorrectMessageLengthOrInvalidFormat`** — the frame itself is malformed:
     ///   too short, too long, or a declared width that does not fit.
@@ -118,21 +133,28 @@ impl Error {
     /// - **`0x31` `requestOutOfRange`** — a *parameter* (not a sub-function) carries a value
     ///   outside its permitted range. Note that `communicationType` is a parameter of
     ///   `CommunicationControl`, not its sub-function, so it lands here rather than on `0x12`.
-    /// - **`0x10` `generalReject`** — reserved for [`Error::IoError`]. A transport failure is
-    ///   not a protocol error and no other code fits; ISO designates `generalReject` for
-    ///   exactly the case where no other response code meets the implementation's needs.
     ///
-    /// The mapping never returns [`NegativeResponseCode::PositiveResponse`] or any reserved
-    /// code, so the result is always a legal NRC to put on the wire.
+    /// Two codes this mapping deliberately never returns:
+    ///
+    /// - **`0x10` `generalReject`** — Annex A.1 says it "shall only be implemented in the server
+    ///   if none of the negative response codes defined in this document meet the needs of the
+    ///   implementation. At no means shall this NRC be a general replacement". It also appears in
+    ///   none of the per-service NRC tables, so no service's `allowed_nack_codes` lists it.
+    /// - **`0x11` `serviceNotSupported`** — an unrecognised SID does not fail to decode; it
+    ///   becomes [`Request::Other`](crate::Request::Other) so a server can see the byte. Answering
+    ///   `0x11` is therefore the server's call, on a SID it does not implement.
+    ///
+    /// Every code this does return is a legal NRC to put on the wire: never
+    /// [`NegativeResponseCode::PositiveResponse`] and never a reserved value.
     #[must_use]
-    pub const fn negative_response_code(&self) -> NegativeResponseCode {
+    pub const fn negative_response_code(&self) -> Option<NegativeResponseCode> {
         match self {
             // The frame is malformed.
             Self::InsufficientData(_)
             | Self::TrailingBytes(_)
             | Self::InvalidWidth(_)
             | Self::IncorrectMessageLengthOrInvalidFormat => {
-                NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat
+                Some(NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat)
             }
 
             // The sub-function byte is not a defined value for the service.
@@ -143,17 +165,20 @@ impl Error {
             | Self::InvalidTesterPresentType(_)
             | Self::InvalidRoutineControlSubFunction(_)
             | Self::InvalidDtcSubfunctionType(_)
-            | Self::InvalidDtcSetting(_) => NegativeResponseCode::SubFunctionNotSupported,
+            | Self::InvalidDtcSetting(_) => Some(NegativeResponseCode::SubFunctionNotSupported),
 
             // A parameter value is outside its permitted range.
             Self::InvalidCommunicationType(_)
             | Self::InvalidMemoryAddress(_)
+            | Self::InvalidAddressAndLengthFormatIdentifier(_)
             | Self::InvalidDtcRecord(_)
             | Self::InvalidEncryptionCompressionMethod(_)
-            | Self::InvalidFileOperationMode(_) => NegativeResponseCode::RequestOutOfRange,
+            | Self::InvalidFileOperationMode(_) => Some(NegativeResponseCode::RequestOutOfRange),
 
-            // Transport failure: not a protocol error, so no specific NRC applies.
-            Self::IoError(_) => NegativeResponseCode::GeneralReject,
+            // Transport failure. ISO does not model this as an NRC at all: clause 7.4.1.6
+            // surfaces it to the server application as `A_Result = error`. There is no byte to
+            // put on the wire, because the wire is what failed.
+            Self::IoError(_) => None,
         }
     }
 }
@@ -296,11 +321,10 @@ mod nrc_mapping_tests {
                 0x31,
                 "a u32 wider than three DTC bytes",
             ),
-            // --- 0x10 generalReject: transport failure, no protocol NRC applies ---
             (
-                Error::IoError(embedded_io::ErrorKind::WriteZero),
-                0x10,
-                "I/O failure",
+                Error::InvalidAddressAndLengthFormatIdentifier(0x00),
+                0x31,
+                "addressAndLengthFormatIdentifier outside Table H.1",
             ),
         ]
         .into_iter()
@@ -309,7 +333,10 @@ mod nrc_mapping_tests {
     #[test]
     fn every_error_maps_to_its_iso_negative_response_code() {
         for (err, want, why) in cases() {
-            let got = u8::from(err.negative_response_code());
+            let nrc = err
+                .negative_response_code()
+                .expect("every case in this table is a protocol error, not a transport one");
+            let got = u8::from(nrc);
             assert_eq!(
                 got, want,
                 "{err:?} ({why}): got 0x{got:02X}, want 0x{want:02X}"
@@ -318,11 +345,16 @@ mod nrc_mapping_tests {
     }
 
     #[test]
-    fn mapping_only_produces_codes_the_iso_tables_allow() {
-        // A decode failure must never be reported as a positive response, and must never
-        // invent a reserved code — either would put an invalid NRC on the wire.
+    fn mapping_never_produces_a_positive_or_reserved_code() {
+        // This is deliberately narrower than "the codes the ISO tables allow": the per-service
+        // tables are a floor, not a ceiling (clause 9.4 — the A.1 codes "shall be used in
+        // addition to" them), so table membership is not the property to assert. What must hold
+        // is that a decode failure never reports a positive response and never invents a
+        // reserved code, either of which would put an illegal byte on the wire.
         for (err, _, why) in cases() {
-            let nrc = err.negative_response_code();
+            let nrc = err
+                .negative_response_code()
+                .expect("every case in this table maps to a code");
             assert_ne!(
                 nrc,
                 NegativeResponseCode::PositiveResponse,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,10 +289,7 @@ mod no_std_api_tests {
         const DTC: DtcRecord = DtcRecord::new(0x01, 0x02, 0x03);
         const SNAPSHOT: DtcSnapshotRecordNumber = DtcSnapshotRecordNumber::new(0x02);
         const EXT_DATA: DtcExtDataRecordNumber = DtcExtDataRecordNumber::new(0x90);
-        const STORED: DtcStoredDataRecordNumber = match DtcStoredDataRecordNumber::new(0x02) {
-            Ok(number) => number,
-            Err(_) => panic!("0x02 is not reserved"),
-        };
+        const STORED: DtcStoredDataRecordNumber = DtcStoredDataRecordNumber::new(0x02);
         const DFI: DataFormatIdentifier = match DataFormatIdentifier::new(0x01, 0x02) {
             Ok(dfi) => dfi,
             Err(_) => panic!("both nibbles are in range"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,10 @@ mod no_std_api_tests {
         assert_eq!(records.len(), 2);
         assert_eq!(u32::from(records[0].0), 0x01_0203);
         assert_eq!(u32::from(records[1].0), 0x04_0506);
+        // The status byte matters as much as the DTC: 0x02 and 0x0A-0x0E are the most-used
+        // sub-functions, and nothing asserted it, so "every DTC reports status 0x00" passed.
+        assert_eq!(records[0].1.bits(), 0x0A);
+        assert_eq!(records[1].1.bits(), 0x0B);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ mod no_std_api_tests {
         assert_eq!(resp.service(), UdsServiceType::RequestUpload);
         match resp {
             Response::RequestUpload(ref up) => {
-                assert_eq!(up.max_number_of_block_length, &[0x08, 0x00]);
+                assert_eq!(up.max_number_of_block_length(), &[0x08, 0x00]);
             }
             other => panic!("expected RequestUpload, got {other:?}"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,6 @@ pub use services::{
 #[cfg(test)]
 mod no_std_api_tests {
     use super::*;
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
     #[test]
     fn encode_decode_tester_present_roundtrip() {
@@ -107,22 +105,29 @@ mod no_std_api_tests {
         assert_eq!(req.service(), UdsServiceType::EcuReset);
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn dtc_and_status_iter_roundtrip() {
         // 2 DTC records: (0x01,0x02,0x03, status=0x0A), (0x04,0x05,0x06, status=0x0B)
+        //
+        // Deliberately not gated on `alloc`, and written with `next()` rather than `collect()`
+        // for that reason. While this was gated, mutating the status byte to a constant left
+        // `--no-default-features` fully green — so the assertion below existed but did not
+        // protect the config the crate targets first.
         let data = [0x01, 0x02, 0x03, 0x0A, 0x04, 0x05, 0x06, 0x0B];
-        let iter = DtcAndStatusIter::new(&data);
+        let mut iter = DtcAndStatusIter::new(&data);
         assert_eq!(iter.len(), 2);
 
-        let records: Vec<_> = iter.map(|r| r.unwrap()).collect();
-        assert_eq!(records.len(), 2);
-        assert_eq!(u32::from(records[0].0), 0x01_0203);
-        assert_eq!(u32::from(records[1].0), 0x04_0506);
+        let (dtc, status) = iter.next().unwrap().unwrap();
+        assert_eq!(u32::from(dtc), 0x01_0203);
         // The status byte matters as much as the DTC: 0x02 and 0x0A-0x0E are the most-used
         // sub-functions, and nothing asserted it, so "every DTC reports status 0x00" passed.
-        assert_eq!(records[0].1.bits(), 0x0A);
-        assert_eq!(records[1].1.bits(), 0x0B);
+        assert_eq!(status.bits(), 0x0A);
+
+        let (dtc, status) = iter.next().unwrap().unwrap();
+        assert_eq!(u32::from(dtc), 0x04_0506);
+        assert_eq!(status.bits(), 0x0B);
+
+        assert!(iter.next().is_none());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,11 +298,53 @@ mod no_std_api_tests {
             Err(_) => panic!("both nibbles are in range"),
         };
 
-        assert_eq!(u32::from(DTC), 0x01_0203);
+        // Getting the byte back out must be const too, or a `const` dispatch table can be
+        // built but not read. These four had only a non-const `From`, so each of these lines
+        // was previously an E0015.
+        const DTC_U32: u32 = DTC.to_u32();
+        const DFI_BYTE: u8 = DFI.value();
+        const NRC_BYTE: u8 = NegativeResponseCode::ConditionsNotCorrect.value();
+        const FORMAT_BYTE: u8 = DtcFormatIdentifier::Iso14229_1DtcFormat.value();
+        const CONTROL_BYTE: u8 = CommunicationControlType::DisableRxAndTx.value();
+
+        assert_eq!(DTC_U32, 0x01_0203);
+        assert_eq!(u32::from(DTC), DTC_U32);
         assert_eq!(SNAPSHOT.value(), 0x02);
         assert_eq!(EXT_DATA.value(), 0x90);
         assert_eq!(STORED.value(), 0x02);
-        assert_eq!(u8::from(DFI), 0x12);
+        assert_eq!(DFI_BYTE, 0x12);
+        assert_eq!(u8::from(DFI), DFI_BYTE);
+        assert_eq!(NRC_BYTE, 0x22);
+        assert_eq!(FORMAT_BYTE, 0x01);
+        assert_eq!(CONTROL_BYTE, 0x03);
+    }
+
+    #[test]
+    fn communication_control_requests_are_const_constructible() {
+        // Both constructors were the crate's only non-`const` `new`s. The blocker was
+        // `u8::from(control_type)` in their error payload, which an inherent `const fn value()`
+        // on the enum removes.
+        const REQ: CommunicationControlRequest = match CommunicationControlRequest::new(
+            false,
+            CommunicationControlType::DisableRxAndTx,
+            CommunicationType::NormalAndNetworkManagement,
+        ) {
+            Ok(req) => req,
+            Err(_) => panic!("DisableRxAndTx takes no node id"),
+        };
+        const WITH_ID: CommunicationControlRequest =
+            match CommunicationControlRequest::new_with_node_id(
+                false,
+                CommunicationControlType::EnableRxAndTxWithEnhancedAddressInfo,
+                CommunicationType::Normal,
+                0x000A,
+            ) {
+                Ok(req) => req,
+                Err(_) => panic!("the enhanced variant requires a node id"),
+            };
+
+        assert_eq!(REQ.control_type(), CommunicationControlType::DisableRxAndTx);
+        assert_eq!(WITH_ID.node_id(), Some(0x000A));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,10 @@ pub use dtc::{
 };
 
 mod shared;
-pub use shared::{DataFormatIdentifier, NegativeResponseCode, UdsIdentifier, UdsRoutineIdentifier};
+pub use shared::{
+    AddressAndLengthFormatIdentifier, DataFormatIdentifier, NegativeResponseCode, UdsIdentifier,
+    UdsRoutineIdentifier,
+};
 
 mod request;
 pub use request::Request;

--- a/src/request.rs
+++ b/src/request.rs
@@ -18,7 +18,7 @@ use super::service::UdsServiceType;
 ///
 /// Variable-length payloads are stored as raw `&'a [u8]` slices that can be
 /// further parsed on demand.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Request<'a> {
     /// Clear diagnostic information request.

--- a/src/request.rs
+++ b/src/request.rs
@@ -194,11 +194,26 @@ impl Request<'_> {
         }
     }
 
-    /// The [`NegativeResponseCode`]s this request's service is allowed to be answered with.
+    /// The [`NegativeResponseCode`]s ISO 14229-1 **lists** for this request's service.
     ///
     /// Each request type also exposes this as an associated function (e.g.
     /// [`EcuResetRequest::allowed_nack_codes`]); this dispatches to it for a decoded
     /// [`Request`], so a server does not have to re-match every variant to reach it.
+    ///
+    /// # This is a floor, not a ceiling — do not use it as a validation whitelist
+    ///
+    /// Clause 9.4: the Annex A.1 codes "shall be used **in addition to** the negative response
+    /// codes specified in each service description", and A.1 itself says a server "may also
+    /// utilise additional and applicable negative response codes … as defined by the vehicle
+    /// manufacturer". A.1 deliberately keeps the generally-supported codes out of the
+    /// per-service tables and says so per code — including `0x78`
+    /// [`RequestCorrectlyReceivedResponsePending`](NegativeResponseCode::RequestCorrectlyReceivedResponsePending),
+    /// which appears in **none** of these tables and is one of the most common codes in real
+    /// traffic. A client that rejected any NRC absent from this slice would reject every
+    /// `ResponsePending` it ever saw.
+    ///
+    /// Read it as "the codes the standard tabulates for this service", which is useful for
+    /// building a tester UI or a conformance report, and not as the set a server may send.
     ///
     /// Returns an empty slice for [`Request::Other`], which covers services the crate does not
     /// model. That means "the NRC set is unknown", not "no codes apply" — consult ISO 14229-1
@@ -313,6 +328,11 @@ mod tests {
         // Each frame is paired with the inherent table it must dispatch to. Asserting only
         // `!is_empty()` made the test vacuous: every modeled service has a non-empty table, so
         // any arm could return any *other* service's set and still pass.
+        //
+        // Two pairs remain indistinguishable, and that is correct rather than a gap: ISO gives
+        // CommunicationControl and ControlDTCSetting the same four codes, and Tables 444 and 449
+        // give RequestDownload and RequestUpload the same six. Swapping either pair's arms is
+        // unobservable because the answer is the same, so there is nothing here to pin.
         let frames: [(&[u8], &'static [NegativeResponseCode]); 16] = [
             (
                 &[0x14, 0xFF, 0xFF, 0xFF, 0x00],

--- a/src/request.rs
+++ b/src/request.rs
@@ -305,29 +305,72 @@ mod tests {
 
     #[test]
     fn allowed_nack_codes_dispatches_for_every_modeled_variant() {
-        // Every one of the 15 request types has an inherent `allowed_nack_codes()`, but
+        // Every one of the 16 request types has an inherent `allowed_nack_codes()`, but
         // without this dispatcher a caller holding a *decoded* `Request` had to re-match all
-        // 15 variants to reach it — on a `#[non_exhaustive]` enum they cannot match
+        // 16 variants to reach it — on a `#[non_exhaustive]` enum they cannot match
         // exhaustively. Frames are minimal-but-valid for each service.
-        let frames: [&[u8]; 16] = [
-            &[0x14, 0xFF, 0xFF, 0xFF, 0x00], // ClearDiagnosticInfo (groupOfDTC + memorySelection)
-            &[0x28, 0x00, 0x01],             // CommunicationControl
-            &[0x85, 0x01],                   // ControlDtcSetting
-            &[0x10, 0x01],                   // DiagnosticSessionControl
-            &[0x11, 0x01],                   // EcuReset
-            &[0x22, 0xF1, 0x90],             // ReadDataByIdentifier
-            &[0x19, 0x02, 0xFF],             // ReadDtcInfo
-            &[0x34, 0x00, 0x12, 0xBE, 0xEF, 0x10], // RequestDownload
-            &[0x38, 0x02, 0x00, 0x01, b'a'], // RequestFileTransfer
-            &[0x35, 0x00, 0x12, 0xBE, 0xEF, 0x10], // RequestUpload
-            &[0x37],                         // RequestTransferExit
-            &[0x31, 0x01, 0xFF, 0x00],       // RoutineControl
-            &[0x27, 0x01, 0xAA],             // SecurityAccess
-            &[0x3E, 0x00],                   // TesterPresent
-            &[0x36, 0x01, 0xAA],             // TransferData
-            &[0x2E, 0xF1, 0x90, 0x01],       // WriteDataByIdentifier
+        //
+        // Each frame is paired with the inherent table it must dispatch to. Asserting only
+        // `!is_empty()` made the test vacuous: every modeled service has a non-empty table, so
+        // any arm could return any *other* service's set and still pass.
+        let frames: [(&[u8], &'static [NegativeResponseCode]); 16] = [
+            (
+                &[0x14, 0xFF, 0xFF, 0xFF, 0x00],
+                ClearDiagnosticInfoRequest::allowed_nack_codes(),
+            ),
+            (
+                &[0x28, 0x00, 0x01],
+                CommunicationControlRequest::allowed_nack_codes(),
+            ),
+            (
+                &[0x85, 0x01],
+                ControlDtcSettingRequest::allowed_nack_codes(),
+            ),
+            (
+                &[0x10, 0x01],
+                DiagnosticSessionControlRequest::allowed_nack_codes(),
+            ),
+            (&[0x11, 0x01], EcuResetRequest::allowed_nack_codes()),
+            (
+                &[0x22, 0xF1, 0x90],
+                ReadDataByIdentifierRequest::allowed_nack_codes(),
+            ),
+            (
+                &[0x19, 0x02, 0xFF],
+                ReadDtcInfoRequest::allowed_nack_codes(),
+            ),
+            (
+                &[0x34, 0x00, 0x12, 0xBE, 0xEF, 0x10],
+                RequestDownloadRequest::allowed_nack_codes(),
+            ),
+            (
+                &[0x38, 0x02, 0x00, 0x01, b'a'],
+                RequestFileTransferRequest::allowed_nack_codes(),
+            ),
+            (
+                &[0x35, 0x00, 0x12, 0xBE, 0xEF, 0x10],
+                RequestUploadRequest::allowed_nack_codes(),
+            ),
+            (&[0x37], RequestTransferExitRequest::allowed_nack_codes()),
+            (
+                &[0x31, 0x01, 0xFF, 0x00],
+                RoutineControlRequest::allowed_nack_codes(),
+            ),
+            (
+                &[0x27, 0x01, 0xAA],
+                SecurityAccessRequest::allowed_nack_codes(),
+            ),
+            (&[0x3E, 0x00], TesterPresentRequest::allowed_nack_codes()),
+            (
+                &[0x36, 0x01, 0xAA],
+                TransferDataRequest::allowed_nack_codes(),
+            ),
+            (
+                &[0x2E, 0xF1, 0x90, 0x01],
+                WriteDataByIdentifierRequest::allowed_nack_codes(),
+            ),
         ];
-        for frame in frames {
+        for (frame, expected) in frames {
             let (req, _) = Request::decode(frame).unwrap_or_else(|e| {
                 panic!("frame {frame:02X?} should decode, got {e:?}");
             });
@@ -335,9 +378,10 @@ mod tests {
                 !matches!(req, Request::Other { .. }),
                 "frame {frame:02X?} decoded to Other; the table needs updating"
             );
-            assert!(
-                !req.allowed_nack_codes().is_empty(),
-                "{:?} returned no NRCs",
+            assert_eq!(
+                req.allowed_nack_codes(),
+                expected,
+                "{:?} dispatched to the wrong NRC table",
                 req.service()
             );
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -12,7 +12,7 @@ use automotive_wire_codec::{write_all, write_u8};
 ///
 /// Variable-length payloads are stored as raw `&'a [u8]` slices that can be
 /// further parsed on demand.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Response<'a> {
     /// Positive response to `ClearDiagnosticInfo`.

--- a/src/service.rs
+++ b/src/service.rs
@@ -329,7 +329,7 @@ mod test {
         (UdsServiceType::CommunicationControl, 0x28, 0x68),
         (UdsServiceType::Authentication, 0x29, 0x69),
         (UdsServiceType::ReadDataByIdentifierPeriodic, 0x2A, 0x6A),
-        (UdsServiceType::DynamicallyDefinedDataIdentifier, 0x2C, 0x6C),
+        (UdsServiceType::DynamicallyDefineDataIdentifier, 0x2C, 0x6C),
         (UdsServiceType::WriteDataByIdentifier, 0x2E, 0x6E),
         (UdsServiceType::InputOutputControlByIdentifier, 0x2F, 0x6F),
         (UdsServiceType::RoutineControl, 0x31, 0x71),

--- a/src/service.rs
+++ b/src/service.rs
@@ -50,6 +50,11 @@ pub enum UdsServiceType {
     /// If these timings are exceeded without a message being sent,
     /// it must be assumed that the connection was interrupted.
     /// These timings can be read and changed through this service.
+    ///
+    /// Defined in ISO 14229-1:2013 and **removed in the 2020 edition**, which this crate
+    /// otherwise targets. The variant is retained so a 2013-era `0x83`/`0xC3` byte round-trips
+    /// as itself rather than becoming an unrecognized
+    /// [`Request::Other`](crate::Request::Other); no request or response type models it.
     AccessTimingParameters,
     /// Transmit data using a security sub-layer (ISO 15764).
     SecuredDataTransmission,
@@ -83,7 +88,7 @@ pub enum UdsServiceType {
     /// - Source DID, position, length (in bytes), Sub-Function Byte: defineByIdentifier
     /// - Memory address length (in bytes), Sub-Function Byte: defineByMemoryAddress
     /// - Combinations of the two above methods through multiple requests.
-    DynamicallyDefinedDataIdentifier,
+    DynamicallyDefineDataIdentifier,
     /// Change the specified Data Identifier (DID) to the provided value
     WriteDataByIdentifier,
     /// Write information into the ECU at one or more contiguous memory locations.
@@ -162,7 +167,7 @@ impl UdsServiceType {
             0x23 => Self::ReadMemoryByAddress,
             0x24 => Self::ReadScalingDataByIdentifier,
             0x2A => Self::ReadDataByIdentifierPeriodic,
-            0x2C => Self::DynamicallyDefinedDataIdentifier,
+            0x2C => Self::DynamicallyDefineDataIdentifier,
             0x2E => Self::WriteDataByIdentifier,
             0x3D => Self::WriteMemoryByAddress,
             0x14 => Self::ClearDiagnosticInfo,
@@ -204,7 +209,7 @@ impl UdsServiceType {
             Self::ReadMemoryByAddress => 0x23,
             Self::ReadScalingDataByIdentifier => 0x24,
             Self::ReadDataByIdentifierPeriodic => 0x2A,
-            Self::DynamicallyDefinedDataIdentifier => 0x2C,
+            Self::DynamicallyDefineDataIdentifier => 0x2C,
             Self::WriteDataByIdentifier => 0x2E,
             Self::WriteMemoryByAddress => 0x3D,
             Self::ClearDiagnosticInfo => 0x14,
@@ -240,7 +245,7 @@ impl UdsServiceType {
             0x63 => Self::ReadMemoryByAddress,
             0x64 => Self::ReadScalingDataByIdentifier,
             0x6A => Self::ReadDataByIdentifierPeriodic,
-            0x6C => Self::DynamicallyDefinedDataIdentifier,
+            0x6C => Self::DynamicallyDefineDataIdentifier,
             0x6E => Self::WriteDataByIdentifier,
             0x7D => Self::WriteMemoryByAddress,
             0x54 => Self::ClearDiagnosticInfo,
@@ -279,7 +284,7 @@ impl UdsServiceType {
             Self::ReadMemoryByAddress => 0x63,
             Self::ReadScalingDataByIdentifier => 0x64,
             Self::ReadDataByIdentifierPeriodic => 0x6A,
-            Self::DynamicallyDefinedDataIdentifier => 0x6C,
+            Self::DynamicallyDefineDataIdentifier => 0x6C,
             Self::WriteDataByIdentifier => 0x6E,
             Self::WriteMemoryByAddress => 0x7D,
             Self::ClearDiagnosticInfo => 0x54,

--- a/src/services/clear_dtc_information.rs
+++ b/src/services/clear_dtc_information.rs
@@ -185,14 +185,16 @@ mod request {
         let (req, rest) =
             <ClearDiagnosticInfoRequest as Decode>::decode(&[0x01, 0x02, 0x03, 0x2A]).unwrap();
         assert_eq!(req.memory_selection, Some(0x2A));
-        assert_eq!(req.group_of_dtc, DtcRecord::from(0x01_0203));
+        assert_eq!(req.group_of_dtc, DtcRecord::try_from(0x01_0203).unwrap());
         assert!(rest.is_empty());
     }
 
     #[test]
     fn a_request_with_a_memory_selection_encodes_four_bytes() {
-        let req =
-            ClearDiagnosticInfoRequest::new_with_memory_selection(DtcRecord::from(0x01_0203), 0x2A);
+        let req = ClearDiagnosticInfoRequest::new_with_memory_selection(
+            DtcRecord::try_from(0x01_0203).unwrap(),
+            0x2A,
+        );
         let mut buf = [0u8; 8];
         let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(&buf[..written], &[0x01, 0x02, 0x03, 0x2A]);

--- a/src/services/communication_control.rs
+++ b/src/services/communication_control.rs
@@ -831,12 +831,9 @@ mod response {
 ///
 /// This doc comment is the published schema description for `CommunicationControlRequest`,
 /// because its hand-written `PartialSchema` delegates here.
-#[cfg(any(feature = "serde", feature = "utoipa"))]
+#[cfg(feature = "serde")]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-// With `utoipa` but not `serde` these fields are never read: they exist to give the schema its
-// shape, which the derive reads at compile time rather than at run time.
-#[cfg_attr(not(feature = "serde"), allow(dead_code))]
 struct CommunicationControlRepr {
     suppress_positive_response: bool,
     control_type: CommunicationControlType,

--- a/src/services/communication_control.rs
+++ b/src/services/communication_control.rs
@@ -791,10 +791,7 @@ mod request {
 mod response {
     use super::*;
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn simple_response() {
         let bytes: [u8; 1] = [0x01];
@@ -804,10 +801,9 @@ mod response {
             CommunicationControlType::EnableRxAndDisableTx
         );
 
-        let mut buffer = Vec::new();
-        let written = Encode::encode(&res, &mut buffer).unwrap();
-        assert_eq!(written, 1);
-        assert_eq!(buffer.len(), written);
+        let mut buffer = [0u8; 4];
+        let written = Encode::encode(&res, &mut buffer.as_mut_slice()).unwrap();
+        assert_eq!(&buffer[..written], &bytes);
         assert_encode_size_agrees(&res);
     }
 }
@@ -820,6 +816,9 @@ mod response {
 #[cfg(any(feature = "serde", feature = "utoipa"))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+// With `utoipa` but not `serde` these fields are never read: they exist to give the schema its
+// shape, which the derive reads at compile time rather than at run time.
+#[cfg_attr(not(feature = "serde"), allow(dead_code))]
 struct CommunicationControlRepr {
     suppress_positive_response: bool,
     control_type: CommunicationControlType,

--- a/src/services/communication_control.rs
+++ b/src/services/communication_control.rs
@@ -10,8 +10,8 @@ use automotive_wire_codec::{write_all, write_u8, write_u16_be};
 /// Conversions from `u8` to `CommunicationControlType` are fallible and will return an [`Error`] if the
 /// Suppress Positive Response bit is set.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CommunicationControlType {
@@ -182,7 +182,7 @@ mod communication_control_type_tests {
 /// See ISO 14229-1:2020 Annex B Table B.1. The low nibble of the same byte is the
 /// [`CommunicationType`].
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum SubnetNumber {
@@ -213,6 +213,12 @@ impl SubnetNumber {
     }
 }
 
+impl From<SubnetNumber> for u8 {
+    fn from(subnet: SubnetNumber) -> Self {
+        subnet.value()
+    }
+}
+
 impl TryFrom<u8> for SubnetNumber {
     type Error = Error;
 
@@ -237,8 +243,8 @@ impl TryFrom<u8> for SubnetNumber {
 ///
 /// Conversions from `u8` to `CommunicationType` are fallible and will return an [`Error`] if the value is not a valid `CommunicationType`
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CommunicationType {

--- a/src/services/communication_control.rs
+++ b/src/services/communication_control.rs
@@ -59,6 +59,27 @@ pub enum CommunicationControlType {
 }
 
 impl CommunicationControlType {
+    /// The raw sub-function byte, without the SPRMIB bit.
+    ///
+    /// `const` so [`CommunicationControlRequest::new`] and
+    /// [`new_with_node_id`](CommunicationControlRequest::new_with_node_id) can be `const` too:
+    /// they need the byte for their error payload, and `u8::from` is a trait method, which is
+    /// not callable in a `const fn` on stable.
+    #[must_use]
+    pub const fn value(&self) -> u8 {
+        match self {
+            Self::EnableRxAndTx => 0x00,
+            Self::EnableRxAndDisableTx => 0x01,
+            Self::DisableRxAndEnableTx => 0x02,
+            Self::DisableRxAndTx => 0x03,
+            Self::EnableRxAndDisableTxWithEnhancedAddressInfo => 0x04,
+            Self::EnableRxAndTxWithEnhancedAddressInfo => 0x05,
+            Self::IsoSaeReserved(value)
+            | Self::VehicleManufacturerSpecific(value)
+            | Self::SystemSupplierSpecific(value) => *value,
+        }
+    }
+
     /// Returns `true` if this control type requires an enhanced-address node identifier.
     #[must_use]
     pub const fn is_extended_address_variant(&self) -> bool {
@@ -71,19 +92,8 @@ impl CommunicationControlType {
 }
 
 impl From<CommunicationControlType> for u8 {
-    #[allow(clippy::match_same_arms)]
     fn from(value: CommunicationControlType) -> Self {
-        match value {
-            CommunicationControlType::EnableRxAndTx => 0x00,
-            CommunicationControlType::EnableRxAndDisableTx => 0x01,
-            CommunicationControlType::DisableRxAndEnableTx => 0x02,
-            CommunicationControlType::DisableRxAndTx => 0x03,
-            CommunicationControlType::EnableRxAndDisableTxWithEnhancedAddressInfo => 0x04,
-            CommunicationControlType::EnableRxAndTxWithEnhancedAddressInfo => 0x05,
-            CommunicationControlType::IsoSaeReserved(val) => val,
-            CommunicationControlType::VehicleManufacturerSpecific(val) => val,
-            CommunicationControlType::SystemSupplierSpecific(val) => val,
-        }
+        value.value()
     }
 }
 
@@ -396,15 +406,13 @@ impl CommunicationControlRequest {
     /// Returns [`Error::InvalidCommunicationControlType`] if `control_type` is an
     /// enhanced-address variant — those require a node identifier and must be built
     /// with [`new_with_node_id`](Self::new_with_node_id).
-    pub fn new(
+    pub const fn new(
         suppress_positive_response: bool,
         control_type: CommunicationControlType,
         communication_type: CommunicationType,
     ) -> Result<Self, Error> {
         if control_type.is_extended_address_variant() {
-            return Err(Error::InvalidCommunicationControlType(u8::from(
-                control_type,
-            )));
+            return Err(Error::InvalidCommunicationControlType(control_type.value()));
         }
         Ok(Self {
             suppress_positive_response,
@@ -421,16 +429,14 @@ impl CommunicationControlRequest {
     /// Returns [`Error::InvalidCommunicationControlType`] if `control_type` is not an
     /// enhanced-address variant — a node identifier is only carried by the
     /// `*WithEnhancedAddressInfo` variants.
-    pub fn new_with_node_id(
+    pub const fn new_with_node_id(
         suppress_positive_response: bool,
         control_type: CommunicationControlType,
         communication_type: CommunicationType,
         node_id: u16,
     ) -> Result<Self, Error> {
         if !control_type.is_extended_address_variant() {
-            return Err(Error::InvalidCommunicationControlType(u8::from(
-                control_type,
-            )));
+            return Err(Error::InvalidCommunicationControlType(control_type.value()));
         }
         Ok(Self {
             suppress_positive_response,

--- a/src/services/communication_control.rs
+++ b/src/services/communication_control.rs
@@ -253,11 +253,14 @@ impl TryFrom<u8> for SubnetNumber {
 ///
 /// Conversions from `u8` to `CommunicationType` are fallible and will return an [`Error`] if the value is not a valid `CommunicationType`
 ///
-/// Unlike the other single-byte types here, `serde` uses the derived variant-name form rather
-/// than routing through `u8`. There is nothing to smuggle — the four variants are in bijection
-/// with `0x00..=0x03` and `TryFrom<u8>` accepts all four — and the byte form would be *worse*:
-/// `TryFrom<u8>` reads bits 1-0 of a whole `communicationType` byte and masks the rest, so
-/// deserializing `17` would silently yield `Normal` and re-serialize as `1`.
+/// Serializes as its variant name (`"Normal"`), not as a number — unlike the other single-byte
+/// types in this crate.
+//
+// That is deliberate, and the reason belongs here rather than in the rustdoc, because utoipa
+// publishes the rustdoc as the schema description. There is nothing to smuggle: the four variants
+// are in bijection with 0x00..=0x03 and TryFrom<u8> accepts all four. Routing serde through the
+// byte would be *worse*, because TryFrom<u8> reads bits 1-0 of a whole communicationType byte and
+// masks the rest -- so deserializing 17 would silently yield Normal and re-serialize as 1.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
@@ -820,11 +823,14 @@ mod response {
     }
 }
 
-/// The serde/`OpenAPI` shape of [`CommunicationControlRequest`].
+/// A `CommunicationControl` (0x28) request.
 ///
-/// Deserializing routes through the constructors, so the rule that `node_id` is present exactly
-/// when `control_type` is an enhanced-address variant -- the reason those fields are private --
-/// still holds for a value that arrived as JSON.
+/// `node_id` must be present exactly when `control_type` is one of the two enhanced-address
+/// variants (`0x04`, `0x05`) and absent otherwise; a payload that breaks that rule is rejected
+/// rather than encoded into a frame this crate's own decoder would refuse.
+///
+/// This doc comment is the published schema description for `CommunicationControlRequest`,
+/// because its hand-written `PartialSchema` delegates here.
 #[cfg(any(feature = "serde", feature = "utoipa"))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -885,5 +891,20 @@ impl utoipa::PartialSchema for CommunicationControlRequest {
 impl utoipa::ToSchema for CommunicationControlRequest {
     fn name() -> std::borrow::Cow<'static, str> {
         std::borrow::Cow::Borrowed("CommunicationControlRequest")
+    }
+
+    /// Register the child schemas this one `$ref`s.
+    ///
+    /// `ToSchema::schemas` defaults to a no-op, and the derive is what normally overrides it. A
+    /// hand-written impl that only implements `schema()` therefore emits `$ref`s to types the
+    /// document never defines, which every client generator either rejects or degrades to an
+    /// untyped object -- strictly worse than the derived schema it replaced.
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        <CommunicationControlRepr as utoipa::ToSchema>::schemas(schemas);
     }
 }

--- a/src/services/communication_control.rs
+++ b/src/services/communication_control.rs
@@ -366,7 +366,13 @@ const COMMUNICATION_CONTROL_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 4] =
 
 /// Request for the server to change communication behavior
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "serde",
+    serde(
+        try_from = "CommunicationControlRepr",
+        into = "CommunicationControlRepr"
+    )
+)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct CommunicationControlRequest {
@@ -803,5 +809,70 @@ mod response {
         assert_eq!(written, 1);
         assert_eq!(buffer.len(), written);
         assert_encode_size_agrees(&res);
+    }
+}
+
+/// The serde/`OpenAPI` shape of [`CommunicationControlRequest`].
+///
+/// Deserializing routes through the constructors, so the rule that `node_id` is present exactly
+/// when `control_type` is an enhanced-address variant -- the reason those fields are private --
+/// still holds for a value that arrived as JSON.
+#[cfg(any(feature = "serde", feature = "utoipa"))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+struct CommunicationControlRepr {
+    suppress_positive_response: bool,
+    control_type: CommunicationControlType,
+    communication_type: CommunicationType,
+    subnet: SubnetNumber,
+    node_id: Option<u16>,
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<CommunicationControlRepr> for CommunicationControlRequest {
+    type Error = Error;
+
+    fn try_from(repr: CommunicationControlRepr) -> Result<Self, Error> {
+        let request = match repr.node_id {
+            Some(node_id) => CommunicationControlRequest::new_with_node_id(
+                repr.suppress_positive_response,
+                repr.control_type,
+                repr.communication_type,
+                node_id,
+            )?,
+            None => CommunicationControlRequest::new(
+                repr.suppress_positive_response,
+                repr.control_type,
+                repr.communication_type,
+            )?,
+        };
+        Ok(request.with_subnet(repr.subnet))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<CommunicationControlRequest> for CommunicationControlRepr {
+    fn from(request: CommunicationControlRequest) -> Self {
+        Self {
+            suppress_positive_response: request.suppress_positive_response,
+            control_type: request.control_type(),
+            communication_type: request.communication_type(),
+            subnet: request.subnet(),
+            node_id: request.node_id(),
+        }
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl utoipa::PartialSchema for CommunicationControlRequest {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        <CommunicationControlRepr as utoipa::PartialSchema>::schema()
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl utoipa::ToSchema for CommunicationControlRequest {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("CommunicationControlRequest")
     }
 }

--- a/src/services/communication_control.rs
+++ b/src/services/communication_control.rs
@@ -252,8 +252,14 @@ impl TryFrom<u8> for SubnetNumber {
 /// Note:
 ///
 /// Conversions from `u8` to `CommunicationType` are fallible and will return an [`Error`] if the value is not a valid `CommunicationType`
+///
+/// Unlike the other single-byte types here, `serde` uses the derived variant-name form rather
+/// than routing through `u8`. There is nothing to smuggle — the four variants are in bijection
+/// with `0x00..=0x03` and `TryFrom<u8>` accepts all four — and the byte form would be *worse*:
+/// `TryFrom<u8>` reads bits 1-0 of a whole `communicationType` byte and masks the rest, so
+/// deserializing `17` would silently yield `Normal` and re-serialize as `1`.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/src/services/control_dtc_settings.rs
+++ b/src/services/control_dtc_settings.rs
@@ -208,20 +208,17 @@ impl<'a> Decode<'a> for ControlDtcSettingResponse {
 mod request {
     use super::*;
     use crate::{Decode, Encode, NegativeResponseCode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::{vec, vec::Vec};
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn simple_request() {
         let req = ControlDtcSettingRequest::new(true, DtcSettingType::On);
-        let mut buffer = Vec::new();
-        let written = Encode::encode(&req, &mut buffer).unwrap();
-        assert_eq!(buffer, vec![0x81]);
-        assert_eq!(written, buffer.len());
-        assert_eq!(req.encoded_size().unwrap(), buffer.len());
+        let mut buffer = [0u8; 4];
+        let written = Encode::encode(&req, &mut buffer.as_mut_slice()).unwrap();
+        assert_eq!(&buffer[..written], &[0x81]);
+        assert_eq!(req.encoded_size().unwrap(), written);
 
-        let (parsed, _) = <ControlDtcSettingRequest as Decode>::decode(&buffer).unwrap();
+        let (parsed, _) =
+            <ControlDtcSettingRequest as Decode>::decode(&buffer[..written]).unwrap();
         assert_eq!(parsed.setting, DtcSettingType::On);
         assert!(parsed.suppress_positive_response);
         assert_encode_size_agrees(&req);
@@ -324,20 +321,17 @@ mod request {
 mod response {
     use super::*;
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::{vec, vec::Vec};
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn simple_response() {
         let req = ControlDtcSettingResponse::new(DtcSettingType::On);
-        let mut buffer = Vec::new();
-        let written = Encode::encode(&req, &mut buffer).unwrap();
-        assert_eq!(buffer, vec![0x01]);
-        assert_eq!(written, buffer.len());
-        assert_eq!(req.encoded_size().unwrap(), buffer.len());
+        let mut buffer = [0u8; 4];
+        let written = Encode::encode(&req, &mut buffer.as_mut_slice()).unwrap();
+        assert_eq!(&buffer[..written], &[0x01]);
+        assert_eq!(req.encoded_size().unwrap(), written);
 
-        let (parsed, _) = <ControlDtcSettingResponse as Decode>::decode(&buffer).unwrap();
+        let (parsed, _) =
+            <ControlDtcSettingResponse as Decode>::decode(&buffer[..written]).unwrap();
         assert_eq!(parsed.setting, DtcSettingType::On);
         assert_encode_size_agrees(&req);
     }

--- a/src/services/control_dtc_settings.rs
+++ b/src/services/control_dtc_settings.rs
@@ -7,7 +7,7 @@ use automotive_wire_codec::{write_all, write_u8};
 ///
 /// Used by [`ControlDtcSettingRequest`] to instruct the server.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/src/services/control_dtc_settings.rs
+++ b/src/services/control_dtc_settings.rs
@@ -217,8 +217,7 @@ mod request {
         assert_eq!(&buffer[..written], &[0x81]);
         assert_eq!(req.encoded_size().unwrap(), written);
 
-        let (parsed, _) =
-            <ControlDtcSettingRequest as Decode>::decode(&buffer[..written]).unwrap();
+        let (parsed, _) = <ControlDtcSettingRequest as Decode>::decode(&buffer[..written]).unwrap();
         assert_eq!(parsed.setting, DtcSettingType::On);
         assert!(parsed.suppress_positive_response);
         assert_encode_size_agrees(&req);
@@ -260,7 +259,7 @@ mod request {
             );
             assert_eq!(
                 err.negative_response_code(),
-                NegativeResponseCode::SubFunctionNotSupported
+                Some(NegativeResponseCode::SubFunctionNotSupported)
             );
         }
     }

--- a/src/services/diagnostic_session_control.rs
+++ b/src/services/diagnostic_session_control.rs
@@ -237,9 +237,17 @@ impl<'a> Decode<'a> for DiagnosticSessionControlRequest {
 pub struct DiagnosticSessionControlResponse {
     /// The session type that is now active.
     pub session_type: DiagnosticSessionType,
-    /// P2 server max timing parameter (milliseconds).
+    /// `P2Server_max`: how long the client should wait for a response, at 1 ms per count.
+    ///
+    /// The stored value *is* the millisecond count (ISO 14229-1:2020 Table 29).
     pub p2_server_max: u16,
-    /// P2* (enhanced) server max timing parameter (milliseconds × 10).
+    /// `P2*Server_max`: the enhanced timeout that applies after a
+    /// [`NegativeResponseCode::RequestCorrectlyReceivedResponsePending`], at **10 ms per
+    /// count**.
+    ///
+    /// Multiply by 10 to get milliseconds: Table 29 gives this parameter a resolution of 10 ms,
+    /// so the stored value is milliseconds ÷ 10 and the maximum is 655 350 ms. Reading it as a
+    /// raw millisecond count under-waits by a factor of ten.
     pub p2_star_server_max: u16,
 }
 

--- a/src/services/diagnostic_session_control.rs
+++ b/src/services/diagnostic_session_control.rs
@@ -297,10 +297,7 @@ impl<'a> Decode<'a> for DiagnosticSessionControlResponse {
 mod request {
     use super::*;
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn test_diagnostic_session_control_request() {
         let bytes: [u8; 1] = [0x02];
@@ -308,9 +305,9 @@ mod request {
         assert!(!req.suppress_positive_response);
         assert_eq!(req.session_type, DiagnosticSessionType::ProgrammingSession);
 
-        let mut buffer = Vec::new();
-        Encode::encode(&req, &mut buffer).unwrap();
-        assert_eq!(buffer, bytes);
+        let mut buffer = [0u8; 4];
+        let written = Encode::encode(&req, &mut buffer.as_mut_slice()).unwrap();
+        assert_eq!(&buffer[..written], &bytes);
         assert_eq!(req.encoded_size().unwrap(), 1);
         assert_encode_size_agrees(&req);
     }
@@ -320,10 +317,7 @@ mod request {
 mod response {
     use super::*;
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn test_diagnostic_session_control_response() {
         let bytes = [0x02, 0x11, 0x22, 0x33, 0x44];
@@ -332,9 +326,9 @@ mod response {
         assert_eq!(resp.p2_server_max, 0x1122);
         assert_eq!(resp.p2_star_server_max, 0x3344);
 
-        let mut buffer = Vec::new();
-        Encode::encode(&resp, &mut buffer).unwrap();
-        assert_eq!(buffer, bytes);
+        let mut buffer = [0u8; 8];
+        let written = Encode::encode(&resp, &mut buffer.as_mut_slice()).unwrap();
+        assert_eq!(&buffer[..written], &bytes);
         assert_eq!(resp.encoded_size().unwrap(), 5);
         assert_encode_size_agrees(&resp);
     }

--- a/src/services/ecu_reset.rs
+++ b/src/services/ecu_reset.rs
@@ -335,16 +335,16 @@ impl<'a> Decode<'a> for EcuResetResponse {
 mod request {
     use super::*;
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn ecu_reset_request() {
         let bytes: [u8; 2] = [0x81, 0x00];
         let req = EcuResetRequest::new(true, ResetType::HardReset);
-        let mut buffer = Vec::new();
-        let written = Encode::encode(&req, &mut buffer).unwrap();
+        let mut buffer = [0u8; 4];
+        let written = Encode::encode(&req, &mut buffer.as_mut_slice()).unwrap();
+        // The request is one byte: the second byte of `bytes` is the next frame's, and the
+        // decoder is expected to leave it alone.
+        assert_eq!(&buffer[..written], &bytes[..1]);
         let (result, _) = <EcuResetRequest as Decode>::decode(&bytes).unwrap();
         assert_eq!(result, req);
 
@@ -358,23 +358,20 @@ mod request {
 mod response {
     use super::*;
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn ecu_reset_response() {
         let bytes: [u8; 2] = [0x04, 0x20];
         let resp =
             EcuResetResponse::new_with_power_down_time(ResetType::EnableRapidPowerShutDown, 0x20);
-        let mut buffer = Vec::new();
-        let written = Encode::encode(&resp, &mut buffer).unwrap();
+        let mut buffer = [0u8; 4];
+        let written = Encode::encode(&resp, &mut buffer.as_mut_slice()).unwrap();
         let (result, _) = <EcuResetResponse as Decode>::decode(&bytes).unwrap();
         assert_eq!(result, resp);
 
         // The encoded bytes themselves, not just their count: without this the two halves of
         // the test are disconnected and swapping the two written bytes goes unnoticed.
-        assert_eq!(buffer, bytes);
+        assert_eq!(&buffer[..written], &bytes);
         assert_eq!(written, 2);
         assert_eq!(written, resp.encoded_size().unwrap());
         assert_encode_size_agrees(&resp);

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -8,7 +8,9 @@ pub use communication_control::{
 };
 
 mod control_dtc_settings;
-pub use control_dtc_settings::{ControlDtcSettingRequest, ControlDtcSettingResponse, DtcSettingType};
+pub use control_dtc_settings::{
+    ControlDtcSettingRequest, ControlDtcSettingResponse, DtcSettingType,
+};
 
 mod diagnostic_session_control;
 pub use diagnostic_session_control::{

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -8,9 +8,7 @@ pub use communication_control::{
 };
 
 mod control_dtc_settings;
-pub use control_dtc_settings::{
-    ControlDtcSettingRequest, ControlDtcSettingResponse, DtcSettingType,
-};
+pub use control_dtc_settings::{ControlDtcSettingRequest, ControlDtcSettingResponse, DtcSettingType};
 
 mod diagnostic_session_control;
 pub use diagnostic_session_control::{

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -970,7 +970,7 @@ impl<'a> ReadDtcInfoResponse<'a> {
     ///
     /// Returns `None` if this is not that variant.
     #[must_use]
-    pub fn fault_detection_iter(&self) -> Option<DtcFaultDetectionIter<'a>> {
+    pub fn dtc_fault_detection_iter(&self) -> Option<DtcFaultDetectionIter<'a>> {
         match self {
             Self::DtcFaultDetectionCounterList { raw_records } => {
                 Some(DtcFaultDetectionIter::new(raw_records))
@@ -1404,7 +1404,7 @@ mod response_decode_tests {
                 let counted = resp
                     .dtc_and_status_iter()
                     .map(Iterator::count)
-                    .or_else(|| resp.fault_detection_iter().map(Iterator::count))
+                    .or_else(|| resp.dtc_fault_detection_iter().map(Iterator::count))
                     .or_else(|| resp.wwh_obd_dtc_severity_iter().map(Iterator::count));
                 // DtcSeverityList has no iterator wired yet, so it has no count to check.
                 if let Some(counted) = counted {
@@ -1453,7 +1453,7 @@ mod response_decode_tests {
             if let Some(mut it) = resp.dtc_and_status_iter() {
                 assert!(it.all(|r| r.is_ok()), "{label}");
             }
-            if let Some(mut it) = resp.fault_detection_iter() {
+            if let Some(mut it) = resp.dtc_fault_detection_iter() {
                 assert!(it.all(|r| r.is_ok()), "{label}");
             }
             if let Some(mut it) = resp.wwh_obd_dtc_severity_iter() {

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -352,6 +352,7 @@ mod read_dtc_info_request_encode_tests {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct DtcFaultDetectionCounterRecord {
     /// The DTC this counter belongs to.
     pub dtc_record: DtcRecord,
@@ -378,6 +379,7 @@ impl DtcFaultDetectionCounterRecord {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ReadDtcInfoSubFunction {
     /// * Parameter: `DtcStatusMask`
     ///

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -499,6 +499,7 @@ pub enum ReadDtcInfoSubFunction {
     ///
     /// The value never has bit 7 set: that bit is SPRMIB and is split off into
     /// [`ReadDtcInfoRequest::suppress_positive_response`] before the sub-function is decoded.
+    #[non_exhaustive]
     IsoSaeReserved(u8),
 }
 

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -352,7 +352,6 @@ mod read_dtc_info_request_encode_tests {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub struct DtcFaultDetectionCounterRecord {
     /// The DTC this counter belongs to.
     pub dtc_record: DtcRecord,

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -1053,7 +1053,7 @@ impl<'a> Decode<'a> for ReadDtcInfoResponse<'a> {
             0x02 | 0x0A | 0x0B | 0x0C | 0x0D | 0x0E | 0x15 => {
                 if buf.is_empty() {
                     return Err(Error::InsufficientData(Incomplete {
-                        needed: 2,
+                        needed: 1,
                         available: buf.len(),
                     }));
                 }
@@ -1076,7 +1076,7 @@ impl<'a> Decode<'a> for ReadDtcInfoResponse<'a> {
             0x08 | 0x09 => {
                 if buf.is_empty() {
                     return Err(Error::InsufficientData(Incomplete {
-                        needed: 2,
+                        needed: 1,
                         available: buf.len(),
                     }));
                 }
@@ -1093,7 +1093,7 @@ impl<'a> Decode<'a> for ReadDtcInfoResponse<'a> {
             0x42 => {
                 if buf.len() < 4 {
                     return Err(Error::InsufficientData(Incomplete {
-                        needed: 5,
+                        needed: 4,
                         available: buf.len(),
                     }));
                 }
@@ -1306,6 +1306,29 @@ mod response_decode_tests {
         let mut buf = [0u8; 16];
         let written = resp.encode_to_slice(&mut buf).unwrap();
         assert_eq!(&buf[..written], &wire);
+    }
+
+    #[test]
+    fn an_insufficient_data_shortfall_measures_both_counts_on_one_buffer() {
+        // `needed` used to include the sub-function byte while `available` was measured after it
+        // was sliced off, so a caller computing `needed - available` got a shortfall one byte
+        // too large. Both are now relative to the payload.
+        for (label, frame, needed, available) in [
+            ("0x01 count", [0x59, 0x01, 0x2F].as_slice(), 4, 1),
+            ("0x02 list", [0x59, 0x02].as_slice(), 1, 0),
+            ("0x08 severity list", [0x59, 0x08].as_slice(), 1, 0),
+            ("0x42 WWH-OBD", [0x59, 0x42, 0x33, 0xFF].as_slice(), 4, 2),
+        ] {
+            let got = Response::decode(frame);
+            let Err(Error::InsufficientData(incomplete)) = got else {
+                panic!("{label}: expected InsufficientData, got {got:?}");
+            };
+            assert_eq!(incomplete.needed, needed, "{label}: wrong `needed`");
+            assert_eq!(
+                incomplete.available, available,
+                "{label}: wrong `available`"
+            );
+        }
     }
 
     #[test]

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -1247,6 +1247,68 @@ mod response_decode_tests {
     }
 
     #[test]
+    fn the_wwh_obd_response_header_and_records_decode_field_by_field() {
+        // ISO 14229-1:2020 Table 332: FGID, DTCStatusAvailabilityMask,
+        // DTCSeverityAvailabilityMask, DTCFormatIdentifier, then 5-byte records of
+        // severity + 3-byte DTC + status.
+        //
+        // Nothing had ever asserted a value this iterator yields, nor any of the four header
+        // fields — every test checked only counts and `is_ok()`. Reversing the header fields, or
+        // swapping severity with status and reversing the DTC bytes, passed the whole suite.
+        let wire = [
+            0x59, 0x42, 0x33, 0xFF, 0xF0, 0x01, 0x80, 0x01, 0x02, 0x03, 0x0A,
+        ];
+        let (resp, _) = Response::decode(&wire).unwrap();
+        let Response::ReadDtcInfo(ReadDtcInfoResponse::WwhObdDtcByMaskRecord {
+            functional_group_identifier,
+            status_availability_mask,
+            severity_availability_mask,
+            format_identifier,
+            ..
+        }) = resp
+        else {
+            panic!("expected a WwhObdDtcByMaskRecord response, got {resp:?}");
+        };
+
+        assert_eq!(
+            functional_group_identifier,
+            FunctionalGroupIdentifier::EmissionsSystemGroup,
+            "0x33 is the emissions group per Table D.15"
+        );
+        assert_eq!(status_availability_mask.bits(), 0xFF);
+        assert_eq!(severity_availability_mask.bits(), 0xF0);
+        assert_eq!(format_identifier, DtcFormatIdentifier::Iso14229_1DtcFormat);
+
+        let Response::ReadDtcInfo(ref inner) = resp else {
+            unreachable!()
+        };
+        let mut records = inner
+            .wwh_obd_dtc_severity_iter()
+            .expect("0x42 carries this iterator");
+        let (severity, dtc, status) = records.next().unwrap().unwrap();
+        assert_eq!(
+            severity,
+            DtcSeverityMask::CheckImmediately,
+            "severity is byte 0"
+        );
+        assert_eq!(
+            dtc,
+            DtcRecord::new(0x01, 0x02, 0x03),
+            "DTC bytes are big-endian"
+        );
+        assert_eq!(
+            status.bits(),
+            0x0A,
+            "status is the last byte, not the first"
+        );
+        assert!(records.next().is_none());
+
+        let mut buf = [0u8; 16];
+        let written = resp.encode_to_slice(&mut buf).unwrap();
+        assert_eq!(&buf[..written], &wire);
+    }
+
+    #[test]
     fn a_dtc_count_response_missing_the_count_is_rejected() {
         // Four payload bytes are mandatory after the sub-function echo; three is a truncated
         // frame, not a frame whose format identifier happens to be the count's high byte.
@@ -1292,14 +1354,18 @@ mod response_decode_tests {
         // A trailing partial record means the frame is malformed. Rejecting it here matches how
         // the crate treats every other length mismatch, and means the iterators returned by the
         // accessors can never see a partial tail.
+        // Every misaligned length below two whole records, which crucially includes 1..width --
+        // a list too short to hold even one record. That range was untested, so a `whole_records`
+        // that accepted any short list passed: 0 records was covered by
+        // `empty_record_lists_are_valid` and 1 record by the aligned test, but the 0-valid /
+        // 1-invalid boundary, the whole point of the check, was not.
         for (label, prefix, width) in LISTS {
-            for extra in 1..width {
-                let (buf, len) = frame(prefix, width + extra);
+            for record_bytes in (1..2 * width).filter(|n| n % width != 0) {
+                let (buf, len) = frame(prefix, record_bytes);
                 let got = <ReadDtcInfoResponse as Decode>::decode(&buf[..len]);
                 assert!(
                     matches!(got, Err(Error::IncorrectMessageLengthOrInvalidFormat)),
-                    "{label}: {} record bytes ({width}+{extra}) should be rejected, got {got:?}",
-                    width + extra
+                    "{label}: {record_bytes} record bytes (width {width}) should be rejected, got {got:?}"
                 );
             }
         }
@@ -1489,17 +1555,33 @@ mod iter_tests {
     #[test]
     fn all_three_iterators_terminate_and_stay_exhausted() {
         // FusedIterator is only sound if `next()` keeps returning None once drained.
+        //
+        // The drains are bounded, like the ones in `size_hint_matches_the_number_of_items_
+        // yielded`: a 7-byte buffer can yield at most 2 items, so `take(8)` cannot hide a real
+        // result, and a regression that stops advancing `remaining` fails here instead of
+        // hanging `cargo test` forever with the other failures unreported.
+        const CAP: usize = 8;
         let data = [0u8; 7]; // not a whole number of records for either width
+
         let mut a = DtcAndStatusIter::new(&data);
-        while a.next().is_some() {}
+        assert!(
+            a.by_ref().take(CAP).count() < CAP,
+            "DtcAndStatusIter did not terminate"
+        );
         assert!(a.next().is_none() && a.next().is_none());
 
         let mut b = DtcFaultDetectionIter::new(&data);
-        while b.next().is_some() {}
+        assert!(
+            b.by_ref().take(CAP).count() < CAP,
+            "DtcFaultDetectionIter did not terminate"
+        );
         assert!(b.next().is_none() && b.next().is_none());
 
         let mut c = WwhObdDtcSeverityIter::new(&data);
-        while c.next().is_some() {}
+        assert!(
+            c.by_ref().take(CAP).count() < CAP,
+            "WwhObdDtcSeverityIter did not terminate"
+        );
         assert!(c.next().is_none() && c.next().is_none());
     }
 

--- a/src/services/read_dtc_information.rs
+++ b/src/services/read_dtc_information.rs
@@ -2,7 +2,7 @@
 
 use automotive_wire_codec::{read_u8, write_all, write_u8, write_u16_be};
 
-use crate::shared::{fuse_sprmib, split_sprmib};
+use crate::shared::{SPRMIB_VALUE_MASK, fuse_sprmib, split_sprmib};
 use crate::{
     Decode, DtcExtDataRecordNumber, DtcFormatIdentifier, DtcRecord, DtcSeverityMask,
     DtcSnapshotRecordNumber, DtcStatusMask, DtcStoredDataRecordNumber, Encode, Error,
@@ -23,7 +23,7 @@ const READ_DTC_INFO_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 3] = [
 pub struct ReadDtcInfoRequest {
     /// Whether the server should suppress a positive response (SPRMIB).
     ///
-    /// ISO 14229-1:2020 Table 13 requires a server to support both values for every
+    /// ISO 14229-1:2020 Table 11 requires a server to support both values for every
     /// sub-function it supports, so this is independent of `dtc_subfunction`.
     pub suppress_positive_response: bool,
     /// The sub-function specifying what DTC information to report.
@@ -78,7 +78,7 @@ impl<'a> Decode<'a> for ReadDtcInfoRequest {
                 available: buf.len(),
             }));
         }
-        // Bit 7 is SPRMIB, not part of the sub-function value (ISO 14229-1:2020 Table 13).
+        // Bit 7 is SPRMIB, not part of the sub-function value (ISO 14229-1:2020 Table 11).
         let (suppress_positive_response, sub) = split_sprmib(buf[0]);
         let rest = &buf[1..];
         let (dtc_subfunction, rest) = match sub {
@@ -213,7 +213,7 @@ mod read_dtc_info_request_encode_tests {
 
     #[test]
     fn both_sprmib_values_round_trip_through_the_request_frame() {
-        // ISO 14229-1:2020 Table 13 requires that "values of both '0' and '1' shall be
+        // ISO 14229-1:2020 Table 11 requires that "values of both '0' and '1' shall be
         // supported for all SubFunction parameter values ... supported by the server for any
         // given service", and clause 12.3.2.2 introduces 0x19's sub-function table with
         // "(suppressPosRspMsgIndicationBit (bit 7) not shown)". A suppressed
@@ -504,6 +504,25 @@ pub enum ReadDtcInfoSubFunction {
 }
 
 impl ReadDtcInfoSubFunction {
+    /// Build the [`IsoSaeReserved`](Self::IsoSaeReserved) variant for a sub-function byte this
+    /// crate does not model.
+    ///
+    /// A tester needs this to originate a request for a report type the crate has not
+    /// implemented — `Self::IsoSaeReserved(byte)` is not writable outside this crate, because
+    /// the variant is `#[non_exhaustive]` to keep bit 7 out of it.
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidDtcSubfunctionType`] if bit 7 is set. That bit is the
+    /// suppressPosRspMsgIndicationBit, not part of the sub-function value: pass it as the first
+    /// argument to [`ReadDtcInfoRequest::new`] instead. Letting it into the variant would make
+    /// `0x80` encode as a suppressed `0x00`.
+    pub const fn try_reserved(byte: u8) -> Result<Self, Error> {
+        if byte & !SPRMIB_VALUE_MASK != 0 {
+            return Err(Error::InvalidDtcSubfunctionType(byte));
+        }
+        Ok(Self::IsoSaeReserved(byte))
+    }
+
     /// Return the raw `u8` sub-function byte.
     #[must_use]
     pub const fn value(&self) -> u8 {

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -19,13 +19,12 @@ fn size_param_width(a: u128, b: u128) -> usize {
 ///////////////////////////////////////// - Request - ///////////////////////////////////////////////////
 /// Mode of operation for file transfer requests
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "serde", serde(from = "u8", into = "u8"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum FileOperationMode {
     /// ISO/SAE reserved (`0x00`, `0x07–0xFF`).
-    #[non_exhaustive]
     IsoSaeReserved(u8),
     /// Add a file to the server
     AddFile = 0x01,
@@ -65,19 +64,28 @@ impl From<FileOperationMode> for u8 {
     }
 }
 
-impl TryFrom<u8> for FileOperationMode {
-    type Error = Error;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
+/// Total, because every byte classifies: Table 485 defines `0x01` to `0x06` and everything else
+/// is `ISOSAEReserved`, which this enum represents rather than rejects. This was a `TryFrom`
+/// whose every arm returned `Ok`, i.e. a fallible signature that could not fail.
+impl From<u8> for FileOperationMode {
+    fn from(value: u8) -> Self {
         match value {
-            0x01 => Ok(Self::AddFile),
-            0x02 => Ok(Self::DeleteFile),
-            0x03 => Ok(Self::ReplaceFile),
-            0x04 => Ok(Self::ReadFile),
-            0x05 => Ok(Self::ReadDir),
-            0x06 => Ok(Self::ResumeFile),
-            0x00 | 0x07..=0xFF => Ok(Self::IsoSaeReserved(value)),
+            0x01 => Self::AddFile,
+            0x02 => Self::DeleteFile,
+            0x03 => Self::ReplaceFile,
+            0x04 => Self::ReadFile,
+            0x05 => Self::ReadDir,
+            0x06 => Self::ResumeFile,
+            0x00 | 0x07..=0xFF => Self::IsoSaeReserved(value),
         }
+    }
+}
+
+impl PartialEq<u8> for FileOperationMode {
+    /// Wire equality: compares the byte this mode encodes to, so a reserved value and the named
+    /// variant carrying the same byte compare equal to that byte.
+    fn eq(&self, other: &u8) -> bool {
+        self.value() == *other
     }
 }
 
@@ -101,7 +109,6 @@ impl TryFrom<u8> for FileOperationMode {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub struct SizePayload {
     /// Specifies the size of the uncompressed file in bytes.
     ///
@@ -168,9 +175,16 @@ impl<'a> NamePayload<'a> {
     /// [`RequestFileTransferRequest`] variant, which writes it. Carrying it here as well let the
     /// two disagree — and the field won, so `AddFile(NamePayload::new(DeleteFile, ..), dfi, size)`
     /// silently encoded a `DeleteFile` request and dropped the format identifier and both sizes.
-    #[must_use]
-    pub const fn new(file_path_and_name: &'a str) -> Self {
-        Self { file_path_and_name }
+    ///
+    /// # Errors
+    /// Returns [`Error::IncorrectMessageLengthOrInvalidFormat`] if the name is longer than
+    /// `u16::MAX` bytes, which is the widest the on-wire `filePathAndNameLength` field can
+    /// declare. This is the invariant that earns this type its `#[non_exhaustive]`.
+    pub const fn new(file_path_and_name: &'a str) -> Result<Self, Error> {
+        if file_path_and_name.len() > u16::MAX as usize {
+            return Err(Error::IncorrectMessageLengthOrInvalidFormat);
+        }
+        Ok(Self { file_path_and_name })
     }
 }
 
@@ -306,11 +320,20 @@ pub struct SentDataPayload<'a> {
 impl<'a> SentDataPayload<'a> {
     /// Build a sent-data payload. The on-wire `lengthFormatIdentifier` is derived from
     /// the length of `max_number_of_block_length` at encode time.
-    #[must_use]
-    pub const fn new(max_number_of_block_length: &'a [u8]) -> Self {
-        Self {
-            max_number_of_block_length,
+    ///
+    /// # Errors
+    /// Returns [`Error::IncorrectMessageLengthOrInvalidFormat`] if the slice is longer than
+    /// 255 bytes. The wire field that carries its length is one byte, so a longer slice was
+    /// constructible here and then failed in `encode` — the same construct-then-fail asymmetry
+    /// that `RequestDownloadResponse::new` was made fallible to close. This is the invariant
+    /// that earns this type its `#[non_exhaustive]`.
+    pub const fn new(max_number_of_block_length: &'a [u8]) -> Result<Self, Error> {
+        if max_number_of_block_length.len() > u8::MAX as usize {
+            return Err(Error::IncorrectMessageLengthOrInvalidFormat);
         }
+        Ok(Self {
+            max_number_of_block_length,
+        })
     }
 }
 
@@ -331,7 +354,6 @@ impl<'a> SentDataPayload<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub struct FileSizePayload {
     /// Size of the uncompressed file in bytes.
     pub file_size_uncompressed: u128,
@@ -372,7 +394,6 @@ impl FileSizePayload {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub struct DirSizePayload {
     /// Total size of the directory information in bytes.
     pub dir_info_length: u128,
@@ -408,7 +429,6 @@ impl DirSizePayload {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub struct PositionPayload {
     /// Specifies the byte position within the file at which the Tester will resume downloading after an initial download is suspended
     /// A download is suspended when the ECU stops receiving [`crate::TransferDataRequest`] requests and does not receive the
@@ -744,7 +764,7 @@ impl<'a> Decode<'a> for RequestFileTransferRequest<'a> {
                 available: buf.len(),
             }));
         };
-        let mode_of_operation = FileOperationMode::try_from(*mode)?;
+        let mode_of_operation = FileOperationMode::from(*mode);
         let (name, rest) = NamePayload::decode(tail)?;
         match mode_of_operation {
             FileOperationMode::DeleteFile => Ok((Self::DeleteFile(name), rest)),
@@ -830,7 +850,7 @@ impl<'a> Decode<'a> for RequestFileTransferResponse<'a> {
                 available: buf.len(),
             }));
         }
-        let mode = FileOperationMode::try_from(buf[0])?;
+        let mode = FileOperationMode::from(buf[0]);
         let rest = &buf[1..];
         match mode {
             FileOperationMode::DeleteFile => Ok((Self::DeleteFile(mode), rest)),
@@ -915,20 +935,17 @@ mod request_tests {
     #[test]
     fn test_file_operation_mode() {
         use FileOperationMode::*;
-        assert_eq!(AddFile, FileOperationMode::try_from(0x01).unwrap());
-        assert_eq!(DeleteFile, FileOperationMode::try_from(0x02).unwrap());
-        assert_eq!(ReplaceFile, FileOperationMode::try_from(0x03).unwrap());
-        assert_eq!(ReadFile, FileOperationMode::try_from(0x04).unwrap());
-        assert_eq!(ReadDir, FileOperationMode::try_from(0x05).unwrap());
-        assert_eq!(ResumeFile, FileOperationMode::try_from(0x06).unwrap());
-        assert_eq!(
-            IsoSaeReserved(0x07),
-            FileOperationMode::try_from(0x07).unwrap()
-        );
+        assert_eq!(AddFile, FileOperationMode::from(0x01));
+        assert_eq!(DeleteFile, FileOperationMode::from(0x02));
+        assert_eq!(ReplaceFile, FileOperationMode::from(0x03));
+        assert_eq!(ReadFile, FileOperationMode::from(0x04));
+        assert_eq!(ReadDir, FileOperationMode::from(0x05));
+        assert_eq!(ResumeFile, FileOperationMode::from(0x06));
+        assert_eq!(IsoSaeReserved(0x07), FileOperationMode::from(0x07));
     }
 
     fn name_payload(path: &str) -> NamePayload<'_> {
-        NamePayload::new(path)
+        NamePayload::new(path).expect("test names are far shorter than u16::MAX")
     }
 
     #[test]
@@ -984,7 +1001,7 @@ mod request_tests {
         // and silently dropped the format identifier and both sizes. With the field gone the
         // variant is the single source of the byte, so that state is unrepresentable.
         let req = RequestFileTransferRequest::AddFile(
-            NamePayload::new("/a"),
+            name_payload("/a"),
             DataFormatIdentifier::NONE,
             SizePayload::new(1, 1),
         );
@@ -1001,11 +1018,11 @@ mod request_tests {
         // ...and every variant reports the byte the spec assigns it (Table 485).
         for (req, byte) in [
             (
-                RequestFileTransferRequest::DeleteFile(NamePayload::new("/a")),
+                RequestFileTransferRequest::DeleteFile(name_payload("/a")),
                 0x02,
             ),
             (
-                RequestFileTransferRequest::ReadDir(NamePayload::new("/a")),
+                RequestFileTransferRequest::ReadDir(name_payload("/a")),
                 0x05,
             ),
         ] {
@@ -1016,7 +1033,7 @@ mod request_tests {
     #[test]
     fn name_payload_length_prefix_matches_name() {
         // The 2-byte length prefix is always exactly the UTF-8 length of the name.
-        let n = NamePayload::new("abc");
+        let n = name_payload("abc");
         let mut buf = [0u8; 16];
         let written = Encode::encode(&n, &mut buf.as_mut_slice()).unwrap();
         // length=0x0003, "abc" — the modeOfOperation byte belongs to the request, not here.
@@ -1102,7 +1119,7 @@ mod response_tests {
     use crate::test_util::assert_encode_size_agrees;
 
     fn sent_data(block: &[u8]) -> SentDataPayload<'_> {
-        SentDataPayload::new(block)
+        SentDataPayload::new(block).expect("test blocks are far shorter than u8::MAX")
     }
 
     #[test]

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -42,17 +42,25 @@ pub enum FileOperationMode {
     ResumeFile = 0x06,
 }
 
+impl FileOperationMode {
+    /// The raw `modeOfOperation` byte. `const`, unlike `u8::from(mode)`.
+    #[must_use]
+    pub const fn value(&self) -> u8 {
+        match self {
+            Self::IsoSaeReserved(value) => *value,
+            Self::AddFile => 0x01,
+            Self::DeleteFile => 0x02,
+            Self::ReplaceFile => 0x03,
+            Self::ReadFile => 0x04,
+            Self::ReadDir => 0x05,
+            Self::ResumeFile => 0x06,
+        }
+    }
+}
+
 impl From<FileOperationMode> for u8 {
     fn from(value: FileOperationMode) -> Self {
-        match value {
-            FileOperationMode::IsoSaeReserved(value) => value,
-            FileOperationMode::AddFile => 0x01,
-            FileOperationMode::DeleteFile => 0x02,
-            FileOperationMode::ReplaceFile => 0x03,
-            FileOperationMode::ReadFile => 0x04,
-            FileOperationMode::ReadDir => 0x05,
-            FileOperationMode::ResumeFile => 0x06,
-        }
+        value.value()
     }
 }
 
@@ -144,9 +152,6 @@ impl SizePayload {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct NamePayload<'a> {
-    /// 0x01 - 0x06, the type of operation to be applied to the file or directory specified in `file_path_and_name`
-    pub mode_of_operation: FileOperationMode,
-
     /// The path and name of the file or directory on the server.
     ///
     /// The on-wire length prefix is derived from this field during encoding, so it can
@@ -157,12 +162,14 @@ pub struct NamePayload<'a> {
 impl<'a> NamePayload<'a> {
     /// Build a name payload. The on-wire length prefix is computed from
     /// `file_path_and_name` at encode time.
+    ///
+    /// The `modeOfOperation` byte is **not** part of this payload: it is the
+    /// [`RequestFileTransferRequest`] variant, which writes it. Carrying it here as well let the
+    /// two disagree — and the field won, so `AddFile(NamePayload::new(DeleteFile, ..), dfi, size)`
+    /// silently encoded a `DeleteFile` request and dropped the format identifier and both sizes.
     #[must_use]
-    pub const fn new(mode_of_operation: FileOperationMode, file_path_and_name: &'a str) -> Self {
-        Self {
-            mode_of_operation,
-            file_path_and_name,
-        }
+    pub const fn new(file_path_and_name: &'a str) -> Self {
+        Self { file_path_and_name }
     }
 }
 
@@ -234,6 +241,21 @@ const REQUEST_FILE_TRANSFER_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 7] =
 ];
 
 impl RequestFileTransferRequest<'_> {
+    /// The `modeOfOperation` this request performs, derived from the variant.
+    ///
+    /// This *is* the variant rather than a stored field, so the two can never disagree.
+    #[must_use]
+    pub const fn mode_of_operation(&self) -> FileOperationMode {
+        match self {
+            Self::AddFile(..) => FileOperationMode::AddFile,
+            Self::DeleteFile(_) => FileOperationMode::DeleteFile,
+            Self::ReplaceFile(..) => FileOperationMode::ReplaceFile,
+            Self::ReadFile(..) => FileOperationMode::ReadFile,
+            Self::ReadDir(_) => FileOperationMode::ReadDir,
+            Self::ResumeFile(..) => FileOperationMode::ResumeFile,
+        }
+    }
+
     /// Get the allowed [`NegativeResponseCode`] variants for this request.
     #[must_use]
     pub fn allowed_nack_codes() -> &'static [NegativeResponseCode] {
@@ -463,8 +485,7 @@ impl Encode for NamePayload<'_> {
         let name = self.file_path_and_name.as_bytes();
         let name_len =
             u16::try_from(name.len()).map_err(|_| Error::IncorrectMessageLengthOrInvalidFormat)?;
-        let mut written = write_u8(writer, u8::from(self.mode_of_operation)).map_err(Error::io)?;
-        written += write_u16_be(writer, name_len).map_err(Error::io)?;
+        let mut written = write_u16_be(writer, name_len).map_err(Error::io)?;
         written += write_all(writer, name).map_err(Error::io)?;
         Ok(written)
     }
@@ -474,30 +495,23 @@ impl<'a> Decode<'a> for NamePayload<'a> {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
-        if buf.len() < 3 {
+        if buf.len() < 2 {
             return Err(Error::InsufficientData(Incomplete {
-                needed: 3,
+                needed: 2,
                 available: buf.len(),
             }));
         }
-        let mode_of_operation = FileOperationMode::try_from(buf[0])?;
-        let name_len = u16::from_be_bytes([buf[1], buf[2]]) as usize;
-        let total = 3 + name_len;
+        let name_len = u16::from_be_bytes([buf[0], buf[1]]) as usize;
+        let total = 2 + name_len;
         if buf.len() < total {
             return Err(Error::InsufficientData(Incomplete {
                 needed: total,
                 available: buf.len(),
             }));
         }
-        let file_path_and_name = core::str::from_utf8(&buf[3..total])
+        let file_path_and_name = core::str::from_utf8(&buf[2..total])
             .map_err(|_| Error::IncorrectMessageLengthOrInvalidFormat)?;
-        Ok((
-            Self {
-                mode_of_operation,
-                file_path_and_name,
-            },
-            &buf[total..],
-        ))
+        Ok((Self { file_path_and_name }, &buf[total..]))
     }
 }
 
@@ -697,21 +711,22 @@ impl Encode for RequestFileTransferRequest<'_> {
     type Error = crate::Error;
 
     fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
-        let mut len;
+        // The mode byte comes from the variant, so it cannot disagree with the payload.
+        let mut len = write_u8(writer, self.mode_of_operation().value()).map_err(Error::io)?;
         match self {
             Self::AddFile(name, dfi, size)
             | Self::ReplaceFile(name, dfi, size)
             | Self::ResumeFile(name, dfi, size) => {
-                len = name.encode(writer)?;
+                len += name.encode(writer)?;
                 len += write_u8(writer, u8::from(*dfi)).map_err(Error::io)?;
                 len += size.encode(writer)?;
             }
             Self::ReadFile(name, dfi) => {
-                len = name.encode(writer)?;
+                len += name.encode(writer)?;
                 len += write_u8(writer, u8::from(*dfi)).map_err(Error::io)?;
             }
             Self::DeleteFile(name) | Self::ReadDir(name) => {
-                len = name.encode(writer)?;
+                len += name.encode(writer)?;
             }
         }
         Ok(len)
@@ -722,8 +737,15 @@ impl<'a> Decode<'a> for RequestFileTransferRequest<'a> {
     type Error = crate::Error;
 
     fn decode(buf: &'a [u8]) -> Result<(Self, &'a [u8]), Error> {
-        let (name, rest) = NamePayload::decode(buf)?;
-        match name.mode_of_operation {
+        let [mode, tail @ ..] = buf else {
+            return Err(Error::InsufficientData(Incomplete {
+                needed: 1,
+                available: buf.len(),
+            }));
+        };
+        let mode_of_operation = FileOperationMode::try_from(*mode)?;
+        let (name, rest) = NamePayload::decode(tail)?;
+        match mode_of_operation {
             FileOperationMode::DeleteFile => Ok((Self::DeleteFile(name), rest)),
             FileOperationMode::ReadDir => Ok((Self::ReadDir(name), rest)),
             FileOperationMode::ReadFile => {
@@ -904,14 +926,14 @@ mod request_tests {
         );
     }
 
-    fn name_payload(mode: FileOperationMode, path: &str) -> NamePayload<'_> {
-        NamePayload::new(mode, path)
+    fn name_payload(path: &str) -> NamePayload<'_> {
+        NamePayload::new(path)
     }
 
     #[test]
     fn name_payload_roundtrip() {
         let path = "/tmp/foo.bin";
-        let n = name_payload(FileOperationMode::AddFile, path);
+        let n = name_payload(path);
         let mut buf = [0u8; 64];
         let written = Encode::encode(&n, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(written, n.encoded_size().unwrap());
@@ -955,20 +977,56 @@ mod request_tests {
     }
 
     #[test]
+    fn the_mode_byte_comes_from_the_variant() {
+        // `NamePayload` used to carry its own `mode_of_operation`, and the field won over the
+        // variant: an `AddFile` request built with a `DeleteFile` payload encoded as DeleteFile
+        // and silently dropped the format identifier and both sizes. With the field gone the
+        // variant is the single source of the byte, so that state is unrepresentable.
+        let req = RequestFileTransferRequest::AddFile(
+            NamePayload::new("/a"),
+            DataFormatIdentifier::NONE,
+            SizePayload::new(1, 1),
+        );
+        assert_eq!(req.mode_of_operation(), FileOperationMode::AddFile);
+
+        let mut buf = [0u8; 16];
+        let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
+        assert_eq!(
+            &buf[..written],
+            &[0x01, 0x00, 0x02, b'/', b'a', 0x00, 0x01, 0x01, 0x01],
+            "mode 0x01, name length 0x0002, \"/a\", DFI, then a 1-byte size pair"
+        );
+
+        // ...and every variant reports the byte the spec assigns it (Table 485).
+        for (req, byte) in [
+            (
+                RequestFileTransferRequest::DeleteFile(NamePayload::new("/a")),
+                0x02,
+            ),
+            (
+                RequestFileTransferRequest::ReadDir(NamePayload::new("/a")),
+                0x05,
+            ),
+        ] {
+            assert_eq!(req.mode_of_operation().value(), byte);
+        }
+    }
+
+    #[test]
     fn name_payload_length_prefix_matches_name() {
         // The 2-byte length prefix is always exactly the UTF-8 length of the name.
-        let n = NamePayload::new(FileOperationMode::DeleteFile, "abc");
+        let n = NamePayload::new("abc");
         let mut buf = [0u8; 16];
         let written = Encode::encode(&n, &mut buf.as_mut_slice()).unwrap();
-        // mode=0x02, length=0x0003, "abc"
-        assert_eq!(&buf[..written], &[0x02, 0x00, 0x03, b'a', b'b', b'c']);
+        // length=0x0003, "abc" — the modeOfOperation byte belongs to the request, not here.
+        assert_eq!(&buf[..written], &[0x00, 0x03, b'a', b'b', b'c']);
     }
 
     #[test]
     fn add_file_request_roundtrip() {
         let path = "test.txt";
         let req = RequestFileTransferRequest::AddFile(
-            name_payload(FileOperationMode::AddFile, path),
+            name_payload(path),
             DataFormatIdentifier::from(0x00),
             SizePayload::new(0x1234, 0x1234),
         );
@@ -984,10 +1042,7 @@ mod request_tests {
     #[test]
     fn delete_file_request_roundtrip() {
         let path = "/var/tmp/delete_file.bin";
-        let req = RequestFileTransferRequest::DeleteFile(name_payload(
-            FileOperationMode::DeleteFile,
-            path,
-        ));
+        let req = RequestFileTransferRequest::DeleteFile(name_payload(path));
         let mut buf = [0u8; 64];
         let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
         assert_eq!(written, req.encoded_size().unwrap());
@@ -1001,7 +1056,7 @@ mod request_tests {
     fn read_file_request_roundtrip() {
         let path = "/etc/passwd";
         let req = RequestFileTransferRequest::ReadFile(
-            name_payload(FileOperationMode::ReadFile, path),
+            name_payload(path),
             DataFormatIdentifier::from(0x11),
         );
         let mut buf = [0u8; 64];
@@ -1016,8 +1071,7 @@ mod request_tests {
     #[test]
     fn read_dir_request_roundtrip() {
         let path = "/var/log";
-        let req =
-            RequestFileTransferRequest::ReadDir(name_payload(FileOperationMode::ReadDir, path));
+        let req = RequestFileTransferRequest::ReadDir(name_payload(path));
         let mut buf = [0u8; 64];
         let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
         let (decoded, _) = RequestFileTransferRequest::decode(&buf[..written]).unwrap();
@@ -1029,7 +1083,7 @@ mod request_tests {
     fn resume_file_request_roundtrip() {
         let path = "/big/file.bin";
         let req = RequestFileTransferRequest::ResumeFile(
-            name_payload(FileOperationMode::ResumeFile, path),
+            name_payload(path),
             DataFormatIdentifier::from(0x00),
             SizePayload::new(0xDEAD_BEEF, 0xDEAD_BEEF),
         );

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -22,6 +22,7 @@ fn size_param_width(a: u128, b: u128) -> usize {
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum FileOperationMode {
     /// ISO/SAE reserved (`0x00`, `0x07–0xFF`).
     IsoSaeReserved(u8),
@@ -91,6 +92,7 @@ impl TryFrom<u8> for FileOperationMode {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct SizePayload {
     /// Specifies the size of the uncompressed file in bytes.
     ///
@@ -140,6 +142,7 @@ impl SizePayload {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct NamePayload<'a> {
     /// 0x01 - 0x06, the type of operation to be applied to the file or directory specified in `file_path_and_name`
     pub mode_of_operation: FileOperationMode,
@@ -256,6 +259,7 @@ impl RequestFileTransferRequest<'_> {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct SentDataPayload<'a> {
     /// This parameter is used by the requestFileTransfer positive response message to inform the client how many
     /// data bytes (maxNumberOfBlockLength) to include in each `TransferData` request message from the client or how
@@ -304,6 +308,7 @@ impl<'a> SentDataPayload<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct FileSizePayload {
     /// Size of the uncompressed file in bytes.
     pub file_size_uncompressed: u128,
@@ -344,6 +349,7 @@ impl FileSizePayload {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct DirSizePayload {
     /// Total size of the directory information in bytes.
     pub dir_info_length: u128,
@@ -379,6 +385,7 @@ impl DirSizePayload {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct PositionPayload {
     /// Specifies the byte position within the file at which the Tester will resume downloading after an initial download is suspended
     /// A download is suspended when the ECU stops receiving [`crate::TransferDataRequest`] requests and does not receive the

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -163,8 +163,17 @@ pub struct NamePayload<'a> {
     /// The path and name of the file or directory on the server.
     ///
     /// The on-wire length prefix is derived from this field during encoding, so it can
-    /// never disagree with the name it describes.
-    pub file_path_and_name: &'a str,
+    /// never disagree with the name it describes. Private because that prefix is two bytes
+    /// wide, which bounds the name; read it back with
+    /// [`NamePayload::file_path_and_name`](Self::file_path_and_name).
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            borrow,
+            deserialize_with = "crate::shared::bounded::str_within_u16_len"
+        )
+    )]
+    file_path_and_name: &'a str,
 }
 
 impl<'a> NamePayload<'a> {
@@ -185,6 +194,12 @@ impl<'a> NamePayload<'a> {
             return Err(Error::IncorrectMessageLengthOrInvalidFormat);
         }
         Ok(Self { file_path_and_name })
+    }
+
+    /// The path and name of the file or directory on the server.
+    #[must_use]
+    pub const fn file_path_and_name(&self) -> &'a str {
+        self.file_path_and_name
     }
 }
 
@@ -314,7 +329,18 @@ pub struct SentDataPayload<'a> {
     /// affect the memory address of where the subsequent transferData request data would be written.
     /// If the modeOfOperation parameter equals to 0x02 (`DeleteFile`) this parameter shall be not be included in the
     /// response message.
-    pub max_number_of_block_length: &'a [u8],
+    ///
+    /// Private because the `lengthFormatIdentifier` that declares its length is one byte wide,
+    /// which bounds it; read it back with
+    /// [`SentDataPayload::max_number_of_block_length`](Self::max_number_of_block_length).
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            borrow,
+            deserialize_with = "crate::shared::bounded::bytes_within_u8_len"
+        )
+    )]
+    max_number_of_block_length: &'a [u8],
 }
 
 impl<'a> SentDataPayload<'a> {
@@ -334,6 +360,13 @@ impl<'a> SentDataPayload<'a> {
         Ok(Self {
             max_number_of_block_length,
         })
+    }
+
+    /// How many data bytes to include in each `TransferData` message, as the raw big-endian
+    /// bytes the server sent.
+    #[must_use]
+    pub const fn max_number_of_block_length(&self) -> &'a [u8] {
+        self.max_number_of_block_length
     }
 }
 

--- a/src/services/request_file_transfer.rs
+++ b/src/services/request_file_transfer.rs
@@ -25,6 +25,7 @@ fn size_param_width(a: u128, b: u128) -> usize {
 #[non_exhaustive]
 pub enum FileOperationMode {
     /// ISO/SAE reserved (`0x00`, `0x07–0xFF`).
+    #[non_exhaustive]
     IsoSaeReserved(u8),
     /// Add a file to the server
     AddFile = 0x01,

--- a/src/services/request_transfer_exit.rs
+++ b/src/services/request_transfer_exit.rs
@@ -5,10 +5,13 @@ use automotive_wire_codec::write_all;
 macro_rules! transfer_exit_descriptor {
     ($name:ident, $doc:literal) => {
         #[doc = $doc]
+        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         #[non_exhaustive]
         pub struct $name<'d> {
             /// The optional, opaque parameter record (empty slice if absent).
+            #[cfg_attr(feature = "serde", serde(borrow))]
             pub parameter_record: &'d [u8],
         }
         impl<'d> $name<'d> {
@@ -73,6 +76,19 @@ mod tests {
     fn test_allowed_nack_codes() {
         let codes = RequestTransferExitRequest::allowed_nack_codes();
         assert!(codes.contains(&NegativeResponseCode::RequestSequenceError));
+    }
+
+    #[test]
+    fn derive_contract() {
+        use crate::test_util::assert_impl_eq;
+        assert_impl_eq::<RequestTransferExitRequest<'static>>();
+        assert_impl_eq::<RequestTransferExitResponse<'static>>();
+        #[cfg(feature = "serde")]
+        {
+            use crate::test_util::assert_impl_serde;
+            assert_impl_serde::<RequestTransferExitRequest<'_>>();
+            assert_impl_serde::<RequestTransferExitResponse<'_>>();
+        }
     }
 
     #[test]

--- a/src/services/routine_control.rs
+++ b/src/services/routine_control.rs
@@ -163,7 +163,17 @@ pub struct RoutineControlResponse<'d> {
     pub sub_function: RoutineControlSubFunction,
     /// The 16-bit routine identifier echoed from the request.
     pub routine_id: u16,
-    /// Optional routine status bytes (may be empty).
+    /// Everything the server sent after the routine identifier — bytes `#5` onward of
+    /// ISO 14229-1:2020 Table 428. May be empty.
+    ///
+    /// Note that this is **not** only the `routineStatusRecord`. Table 428 places an optional
+    /// `routineInfo` byte at `#5`, immediately before the status record, and whether it is
+    /// present is vehicle-manufacturer defined — nothing on the wire distinguishes the two
+    /// layouts, so this crate cannot split them for you. If the server you are talking to sends
+    /// `routineInfo`, it is the first byte here and the status record starts at index 1.
+    ///
+    /// `routineInfo` itself is vehicle-manufacturer specific (Table 429); it exists so generic
+    /// test equipment can handle all implemented routines uniformly.
     #[cfg_attr(feature = "serde", serde(borrow))]
     pub status_record: &'d [u8],
 }
@@ -236,6 +246,30 @@ mod test {
             assert_impl_serde::<RoutineControlRequest<'_>>();
             assert_impl_serde::<RoutineControlResponse<'_>>();
         }
+    }
+
+    #[test]
+    fn status_record_covers_routine_info_as_well() {
+        // ISO 14229-1:2020 Table 428 puts an optional `routineInfo` byte at #5, before the
+        // routineStatusRecord, with presence left to the vehicle manufacturer. Nothing on the
+        // wire distinguishes "routineInfo + status" from "status only", so `status_record`
+        // deliberately spans both and the field docs say so. Pinned here because a future
+        // reader might otherwise "fix" it into a wrong split.
+        let wire = [0x71, 0x01, 0xF0, 0x0F, 0xAA, 0x32];
+        let (resp, _) = crate::Response::decode(&wire).unwrap();
+        let crate::Response::RoutineControl(inner) = resp else {
+            panic!("expected a RoutineControl response, got {resp:?}");
+        };
+        assert_eq!(inner.routine_id, 0xF00F);
+        assert_eq!(
+            inner.status_record,
+            &[0xAA, 0x32],
+            "routineInfo must stay in the slice rather than being silently dropped"
+        );
+
+        let mut buf = [0u8; 8];
+        let written = resp.encode_to_slice(&mut buf).unwrap();
+        assert_eq!(&buf[..written], &wire);
     }
 
     #[test]

--- a/src/services/routine_control.rs
+++ b/src/services/routine_control.rs
@@ -289,7 +289,7 @@ mod test {
             );
             assert_eq!(
                 err.negative_response_code(),
-                NegativeResponseCode::SubFunctionNotSupported,
+                Some(NegativeResponseCode::SubFunctionNotSupported),
                 "wrong NRC for sub-function {byte:#04X}"
             );
         }

--- a/src/services/security_access.rs
+++ b/src/services/security_access.rs
@@ -391,8 +391,6 @@ impl<'a> Decode<'a> for SecurityAccessResponse<'a> {
 mod request {
     use super::*;
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees, test_util::assert_impl_eq};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
     #[test]
     fn derive_contract() {
@@ -406,7 +404,6 @@ mod request {
         }
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn request_seed() {
         let bytes: [u8; 6] = [
@@ -421,9 +418,11 @@ mod request {
         );
         assert_eq!(req.request_data, &[0x00, 0x01, 0x02, 0x03, 0x04]);
 
-        let mut buf = Vec::new();
-        let written = Encode::encode(&req, &mut buf).unwrap();
-        assert_eq!(written, bytes.len());
+        let mut buf = [0u8; 16];
+        let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
+        // The bytes, not just the count: the two halves of this test were otherwise
+        // disconnected, so swapping what `encode` writes went unnoticed.
+        assert_eq!(&buf[..written], &bytes);
         assert_eq!(written, req.encoded_size().unwrap());
         assert_encode_size_agrees(&req);
     }
@@ -433,10 +432,7 @@ mod request {
 mod response {
     use super::*;
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn response_send() {
         let bytes: [u8; 6] = [
@@ -451,9 +447,9 @@ mod response {
         );
         assert_eq!(resp.security_seed, &[0x00, 0x01, 0x02, 0x03, 0x04]);
 
-        let mut buf = Vec::new();
-        let written = Encode::encode(&resp, &mut buf).unwrap();
-        assert_eq!(written, bytes.len());
+        let mut buf = [0u8; 16];
+        let written = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();
+        assert_eq!(&buf[..written], &bytes);
         assert_eq!(written, resp.encoded_size().unwrap());
         assert_encode_size_agrees(&resp);
     }

--- a/src/services/security_access.rs
+++ b/src/services/security_access.rs
@@ -9,8 +9,11 @@ use automotive_wire_codec::{write_all, write_u8};
 /// A request fuses the suppress-positive-response flag into bit 7 of this byte at the wire
 /// boundary, so a level with bit 7 already set would be ambiguous. Constraining construction
 /// here makes that collision unrepresentable rather than something to catch at encode time.
+/// Serializes as the wire byte and validates on the way back in, so `serde` cannot construct a
+/// level `new` would have rejected.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SecurityAccessLevel(u8);
 
@@ -34,6 +37,23 @@ impl SecurityAccessLevel {
     }
 }
 
+impl TryFrom<u8> for SecurityAccessLevel {
+    type Error = Error;
+
+    /// # Errors
+    /// Returns [`Error::InvalidSecurityAccessType`] if `value >= 0x80`; see
+    /// [`SecurityAccessLevel::new`].
+    fn try_from(value: u8) -> Result<Self, Error> {
+        Self::new(value)
+    }
+}
+
+impl From<SecurityAccessLevel> for u8 {
+    fn from(level: SecurityAccessLevel) -> Self {
+        level.0
+    }
+}
+
 /// Security Access Type allows for multiple different security challenges within an ECU.
 ///
 /// The Security Access Type is used to determine both the sub function,
@@ -44,7 +64,7 @@ impl SecurityAccessLevel {
 /// Conversions from `u8` to `SecurityAccessType` are fallible and will return an [`Error`] if the
 /// Suppress Positive Response bit is set.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum SecurityAccessType {

--- a/src/services/tester_present.rs
+++ b/src/services/tester_present.rs
@@ -14,8 +14,6 @@ const NO_SUBFUNCTION_VALUE: u8 = 0x00;
 ///
 /// The range of values is only 7 of the 8 bits, with bit 7 being used as the
 /// Suppress Positive Response (SPR) Message Indication Bit.
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ZeroSubFunction {
     /// Request and response. Indicates that no value beside the SPR Message Indication Bit is supported by this service.
@@ -60,7 +58,10 @@ impl TryFrom<u8> for ZeroSubFunction {
 
 /// Request to indicate the client is still connected
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "serde",
+    serde(try_from = "SubFunctionRepr", into = "SubFunctionRepr")
+)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct TesterPresentRequest {
@@ -140,7 +141,10 @@ impl<'a> Decode<'a> for TesterPresentRequest {
 
 /// Positive response to a `TesterPresentRequest`
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(
+    feature = "serde",
+    serde(try_from = "SubFunctionOnlyRepr", into = "SubFunctionOnlyRepr")
+)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct TesterPresentResponse {
@@ -343,5 +347,98 @@ mod test {
         let expected_bytes = vec![0];
         assert_eq!(buffer, expected_bytes);
         assert_encode_size_agrees(&test_type);
+    }
+}
+
+/// The serde/`OpenAPI` shape of [`TesterPresentRequest`]: its public wire parameters.
+///
+/// Deserializing goes through this rather than the request's own fields, so the sub-function
+/// byte is range-checked on the way in and the private [`ZeroSubFunction`] never appears in the
+/// serialized form or in a generated schema.
+#[cfg(any(feature = "serde", feature = "utoipa"))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+struct SubFunctionRepr {
+    suppress_positive_response: bool,
+    sub_function: u8,
+}
+
+/// The serde/`OpenAPI` shape of [`TesterPresentResponse`], which carries no SPRMIB flag.
+#[cfg(any(feature = "serde", feature = "utoipa"))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+struct SubFunctionOnlyRepr {
+    sub_function: u8,
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<SubFunctionRepr> for TesterPresentRequest {
+    type Error = Error;
+
+    fn try_from(repr: SubFunctionRepr) -> Result<Self, Error> {
+        Ok(Self {
+            suppress_positive_response: repr.suppress_positive_response,
+            zero_sub_function: ZeroSubFunction::try_from(repr.sub_function)?,
+        })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<TesterPresentRequest> for SubFunctionRepr {
+    fn from(request: TesterPresentRequest) -> Self {
+        Self {
+            suppress_positive_response: request.suppress_positive_response,
+            sub_function: request.sub_function(),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<SubFunctionOnlyRepr> for TesterPresentResponse {
+    type Error = Error;
+
+    fn try_from(repr: SubFunctionOnlyRepr) -> Result<Self, Error> {
+        Ok(Self {
+            zero_sub_function: ZeroSubFunction::try_from(repr.sub_function)?,
+        })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<TesterPresentResponse> for SubFunctionOnlyRepr {
+    fn from(response: TesterPresentResponse) -> Self {
+        Self {
+            sub_function: response.sub_function(),
+        }
+    }
+}
+
+// The schema follows the serialized shape, not the Rust fields, for the same reason the serde
+// impls do: `ZeroSubFunction` is module-private and must not surface in a generated client.
+#[cfg(feature = "utoipa")]
+impl utoipa::PartialSchema for TesterPresentRequest {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        <SubFunctionRepr as utoipa::PartialSchema>::schema()
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl utoipa::ToSchema for TesterPresentRequest {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("TesterPresentRequest")
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl utoipa::PartialSchema for TesterPresentResponse {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        <SubFunctionOnlyRepr as utoipa::PartialSchema>::schema()
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl utoipa::ToSchema for TesterPresentResponse {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("TesterPresentResponse")
     }
 }

--- a/src/services/tester_present.rs
+++ b/src/services/tester_present.rs
@@ -350,11 +350,15 @@ mod test {
     }
 }
 
-/// The serde/`OpenAPI` shape of [`TesterPresentRequest`]: its public wire parameters.
-///
-/// Deserializing goes through this rather than the request's own fields, so the sub-function
-/// byte is range-checked on the way in and the private [`ZeroSubFunction`] never appears in the
-/// serialized form or in a generated schema.
+/// A `TesterPresent` (0x3E) request: a suppress-positive-response flag and the sub-function
+/// byte, which ISO 14229-1:2020 Table 119 defines only as `0x00`. Any other value is rejected.
+//
+// This doc comment is published verbatim as `TesterPresentRequest`'s schema description, because
+// its hand-written `PartialSchema` delegates here -- so it has to read as API documentation, and
+// must not name a type a client author cannot reach. The rationale goes in `//` lines for that
+// reason: deserializing routes through this rather than the request's own fields so the
+// sub-function byte is range-checked on the way in, and so the module-private ZeroSubFunction
+// stays out of both the serialized form and the generated schema.
 #[cfg(any(feature = "serde", feature = "utoipa"))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -366,7 +370,8 @@ struct SubFunctionRepr {
     sub_function: u8,
 }
 
-/// The serde/`OpenAPI` shape of [`TesterPresentResponse`], which carries no SPRMIB flag.
+/// A `TesterPresent` (0x7E) positive response: the echoed sub-function byte, and no
+/// suppress-positive-response flag -- a response never carries one.
 #[cfg(any(feature = "serde", feature = "utoipa"))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -433,6 +438,17 @@ impl utoipa::ToSchema for TesterPresentRequest {
     fn name() -> std::borrow::Cow<'static, str> {
         std::borrow::Cow::Borrowed("TesterPresentRequest")
     }
+
+    /// See the note on `CommunicationControlRequest::schemas`: a hand-written `ToSchema` must
+    /// forward this or its `$ref`s dangle.
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        <SubFunctionRepr as utoipa::ToSchema>::schemas(schemas);
+    }
 }
 
 #[cfg(feature = "utoipa")]
@@ -446,5 +462,16 @@ impl utoipa::PartialSchema for TesterPresentResponse {
 impl utoipa::ToSchema for TesterPresentResponse {
     fn name() -> std::borrow::Cow<'static, str> {
         std::borrow::Cow::Borrowed("TesterPresentResponse")
+    }
+
+    /// See the note on `CommunicationControlRequest::schemas`: a hand-written `ToSchema` must
+    /// forward this or its `$ref`s dangle.
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        <SubFunctionOnlyRepr as utoipa::ToSchema>::schemas(schemas);
     }
 }

--- a/src/services/tester_present.rs
+++ b/src/services/tester_present.rs
@@ -14,6 +14,13 @@ const NO_SUBFUNCTION_VALUE: u8 = 0x00;
 ///
 /// The range of values is only 7 of the 8 bits, with bit 7 being used as the
 /// Suppress Positive Response (SPR) Message Indication Bit.
+//
+// `serde(try_from = "u8", into = "u8")` is what keeps a deserialized value inside 0x00..=0x7F:
+// it routes through the `TryFrom<u8>` below, the same classifier `decode` uses. The two public
+// types then just rename the field, so no mirror struct is needed to enforce the range -- the
+// invariant is single-field, and `serde`/`utoipa` can both express that directly.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ZeroSubFunction {
     /// Request and response. Indicates that no value beside the SPR Message Indication Bit is supported by this service.
@@ -58,10 +65,7 @@ impl TryFrom<u8> for ZeroSubFunction {
 
 /// Request to indicate the client is still connected
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(try_from = "SubFunctionRepr", into = "SubFunctionRepr")
-)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct TesterPresentRequest {
@@ -71,6 +75,17 @@ pub struct TesterPresentRequest {
     /// sub-function, so conformant traffic always carries `0x00`; this is kept private so a
     /// caller cannot mint a reserved value, but is retained on decode so that a reserved byte
     /// re-encodes unchanged. Read it back with [`TesterPresentRequest::sub_function`].
+    ///
+    /// Serialized as `sub_function`: a byte in `0x00..=0x7F`.
+    //
+    // The `rename` plus `value_type` is what keeps the private enum out of both the wire format
+    // and the schema. Two mirror structs used to do this; the invariant is single-field, so a
+    // field attribute expresses it directly.
+    #[cfg_attr(feature = "serde", serde(rename = "sub_function"))]
+    #[cfg_attr(
+        feature = "utoipa",
+        schema(rename = "sub_function", value_type = u8, minimum = 0, maximum = 0x7F)
+    )]
     zero_sub_function: ZeroSubFunction,
 }
 
@@ -141,13 +156,16 @@ impl<'a> Decode<'a> for TesterPresentRequest {
 
 /// Positive response to a `TesterPresentRequest`
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(try_from = "SubFunctionOnlyRepr", into = "SubFunctionOnlyRepr")
-)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct TesterPresentResponse {
+    /// The echoed sub-function byte. Serialized as `sub_function`; see the request's field.
+    #[cfg_attr(feature = "serde", serde(rename = "sub_function"))]
+    #[cfg_attr(
+        feature = "utoipa",
+        schema(rename = "sub_function", value_type = u8, minimum = 0, maximum = 0x7F)
+    )]
     zero_sub_function: ZeroSubFunction,
 }
 
@@ -347,131 +365,5 @@ mod test {
         let expected_bytes = vec![0];
         assert_eq!(buffer, expected_bytes);
         assert_encode_size_agrees(&test_type);
-    }
-}
-
-/// A `TesterPresent` (0x3E) request: a suppress-positive-response flag and the sub-function
-/// byte, which ISO 14229-1:2020 Table 119 defines only as `0x00`. Any other value is rejected.
-//
-// This doc comment is published verbatim as `TesterPresentRequest`'s schema description, because
-// its hand-written `PartialSchema` delegates here -- so it has to read as API documentation, and
-// must not name a type a client author cannot reach. The rationale goes in `//` lines for that
-// reason: deserializing routes through this rather than the request's own fields so the
-// sub-function byte is range-checked on the way in, and so the module-private ZeroSubFunction
-// stays out of both the serialized form and the generated schema.
-#[cfg(any(feature = "serde", feature = "utoipa"))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-// With `utoipa` but not `serde` these fields are never read: they exist to give the schema its
-// shape, which the derive reads at compile time rather than at run time.
-#[cfg_attr(not(feature = "serde"), allow(dead_code))]
-struct SubFunctionRepr {
-    suppress_positive_response: bool,
-    sub_function: u8,
-}
-
-/// A `TesterPresent` (0x7E) positive response: the echoed sub-function byte, and no
-/// suppress-positive-response flag -- a response never carries one.
-#[cfg(any(feature = "serde", feature = "utoipa"))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-// With `utoipa` but not `serde` these fields are never read: they exist to give the schema its
-// shape, which the derive reads at compile time rather than at run time.
-#[cfg_attr(not(feature = "serde"), allow(dead_code))]
-struct SubFunctionOnlyRepr {
-    sub_function: u8,
-}
-
-#[cfg(feature = "serde")]
-impl TryFrom<SubFunctionRepr> for TesterPresentRequest {
-    type Error = Error;
-
-    fn try_from(repr: SubFunctionRepr) -> Result<Self, Error> {
-        Ok(Self {
-            suppress_positive_response: repr.suppress_positive_response,
-            zero_sub_function: ZeroSubFunction::try_from(repr.sub_function)?,
-        })
-    }
-}
-
-#[cfg(feature = "serde")]
-impl From<TesterPresentRequest> for SubFunctionRepr {
-    fn from(request: TesterPresentRequest) -> Self {
-        Self {
-            suppress_positive_response: request.suppress_positive_response,
-            sub_function: request.sub_function(),
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl TryFrom<SubFunctionOnlyRepr> for TesterPresentResponse {
-    type Error = Error;
-
-    fn try_from(repr: SubFunctionOnlyRepr) -> Result<Self, Error> {
-        Ok(Self {
-            zero_sub_function: ZeroSubFunction::try_from(repr.sub_function)?,
-        })
-    }
-}
-
-#[cfg(feature = "serde")]
-impl From<TesterPresentResponse> for SubFunctionOnlyRepr {
-    fn from(response: TesterPresentResponse) -> Self {
-        Self {
-            sub_function: response.sub_function(),
-        }
-    }
-}
-
-// The schema follows the serialized shape, not the Rust fields, for the same reason the serde
-// impls do: `ZeroSubFunction` is module-private and must not surface in a generated client.
-#[cfg(feature = "utoipa")]
-impl utoipa::PartialSchema for TesterPresentRequest {
-    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        <SubFunctionRepr as utoipa::PartialSchema>::schema()
-    }
-}
-
-#[cfg(feature = "utoipa")]
-impl utoipa::ToSchema for TesterPresentRequest {
-    fn name() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("TesterPresentRequest")
-    }
-
-    /// See the note on `CommunicationControlRequest::schemas`: a hand-written `ToSchema` must
-    /// forward this or its `$ref`s dangle.
-    fn schemas(
-        schemas: &mut Vec<(
-            String,
-            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
-        )>,
-    ) {
-        <SubFunctionRepr as utoipa::ToSchema>::schemas(schemas);
-    }
-}
-
-#[cfg(feature = "utoipa")]
-impl utoipa::PartialSchema for TesterPresentResponse {
-    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        <SubFunctionOnlyRepr as utoipa::PartialSchema>::schema()
-    }
-}
-
-#[cfg(feature = "utoipa")]
-impl utoipa::ToSchema for TesterPresentResponse {
-    fn name() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("TesterPresentResponse")
-    }
-
-    /// See the note on `CommunicationControlRequest::schemas`: a hand-written `ToSchema` must
-    /// forward this or its `$ref`s dangle.
-    fn schemas(
-        schemas: &mut Vec<(
-            String,
-            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
-        )>,
-    ) {
-        <SubFunctionOnlyRepr as utoipa::ToSchema>::schemas(schemas);
     }
 }

--- a/src/services/tester_present.rs
+++ b/src/services/tester_present.rs
@@ -358,6 +358,9 @@ mod test {
 #[cfg(any(feature = "serde", feature = "utoipa"))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+// With `utoipa` but not `serde` these fields are never read: they exist to give the schema its
+// shape, which the derive reads at compile time rather than at run time.
+#[cfg_attr(not(feature = "serde"), allow(dead_code))]
 struct SubFunctionRepr {
     suppress_positive_response: bool,
     sub_function: u8,
@@ -367,6 +370,9 @@ struct SubFunctionRepr {
 #[cfg(any(feature = "serde", feature = "utoipa"))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+// With `utoipa` but not `serde` these fields are never read: they exist to give the schema its
+// shape, which the derive reads at compile time rather than at run time.
+#[cfg_attr(not(feature = "serde"), allow(dead_code))]
 struct SubFunctionOnlyRepr {
     sub_function: u8,
 }

--- a/src/services/transfer_data.rs
+++ b/src/services/transfer_data.rs
@@ -149,8 +149,6 @@ impl<'a> Decode<'a> for TransferDataResponse<'a> {
 mod request {
     use super::*;
     use crate::{Decode, Encode, NegativeResponseCode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
     #[test]
     fn test_allowed_nack_codes() {
@@ -179,15 +177,14 @@ mod request {
         assert_eq!(req.data, &[0x01, 0x02, 0x03, 0x04]);
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn read_request() {
         let bytes = [0x01, 0x02, 0x03, 0x04];
         let (req, _) = <TransferDataRequest as Decode>::decode(&bytes).unwrap();
 
-        let mut written_bytes = Vec::new();
-        let written = Encode::encode(&req, &mut written_bytes).unwrap();
-        assert_eq!(written, written_bytes.len());
+        let mut written_bytes = [0u8; 16];
+        let written = Encode::encode(&req, &mut written_bytes.as_mut_slice()).unwrap();
+        assert_eq!(&written_bytes[..written], &bytes);
         assert_eq!(written, req.encoded_size().unwrap());
         assert_encode_size_agrees(&req);
     }
@@ -197,18 +194,15 @@ mod request {
 mod response {
     use super::*;
     use crate::{Decode, Encode, test_util::assert_encode_size_agrees};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn simple_response() {
         let bytes = [0x01, 0x02, 0x03, 0x04];
         let (resp, _) = <TransferDataResponse as Decode>::decode(&bytes).unwrap();
 
-        let mut written_bytes = Vec::new();
-        let written = Encode::encode(&resp, &mut written_bytes).unwrap();
-        assert_eq!(written, written_bytes.len());
+        let mut written_bytes = [0u8; 16];
+        let written = Encode::encode(&resp, &mut written_bytes.as_mut_slice()).unwrap();
+        assert_eq!(&written_bytes[..written], &bytes);
         assert_eq!(written, resp.encoded_size().unwrap());
         assert_encode_size_agrees(&resp);
     }

--- a/src/services/upload_download.rs
+++ b/src/services/upload_download.rs
@@ -7,7 +7,10 @@
 //! bytes. Both pairs are generated from one macro so the wire codec has a single source of
 //! truth; a fix to the width-derivation logic cannot land on one service and miss the other.
 
-use crate::shared::{DataFormatIdentifier, LengthFormatIdentifier, MemoryFormatIdentifier};
+use crate::shared::{
+    DataFormatIdentifier, LengthFormatIdentifier, MAX_MEMORY_ADDRESS_LENGTH,
+    MAX_MEMORY_SIZE_LENGTH, MemoryFormatIdentifier,
+};
 use crate::{Decode, Encode, Error, Incomplete, NegativeResponseCode};
 use automotive_wire_codec::{read_be_uint_into, write_all, write_be_uint, write_u8};
 
@@ -98,6 +101,53 @@ macro_rules! upload_download_service {
                 Ok(Self {
                     data_format_identifier,
                     address_and_length_format_identifier,
+                    memory_address,
+                    memory_size,
+                })
+            }
+
+            #[doc = concat!("Create a `", stringify!($req), "` with client-chosen field widths.")]
+            ///
+            /// ISO 14229-1:2020 Table 441 makes the `addressAndLengthFormatIdentifier` a
+            /// client choice rather than a function of the values, and many bootloaders
+            /// require a particular one (often `0x44`) and answer `requestOutOfRange`
+            /// otherwise. [`new`](Self::new) always derives the *minimal* widths, so it cannot
+            /// express a wider-than-minimal declaration; this can.
+            ///
+            /// Widths are in bytes: `memory_address_length` may be 1 through 5 and
+            /// `memory_size_length` 1 through 4 (Annex H Table H.1).
+            ///
+            /// # Errors
+            /// Returns [`Error::IncorrectMessageLengthOrInvalidFormat`] if either width is
+            /// outside the range Table H.1 permits, or if a value does not fit in the width
+            /// declared for it — which would otherwise truncate it on the wire.
+            pub const fn new_with_widths(
+                data_format_identifier: DataFormatIdentifier,
+                memory_address: u64,
+                memory_address_length: u8,
+                memory_size: u32,
+                memory_size_length: u8,
+            ) -> Result<Self, Error> {
+                if memory_address_length < 1
+                    || memory_address_length > MAX_MEMORY_ADDRESS_LENGTH
+                    || memory_size_length < 1
+                    || memory_size_length > MAX_MEMORY_SIZE_LENGTH
+                {
+                    return Err(Error::IncorrectMessageLengthOrInvalidFormat);
+                }
+                // A width of n bytes holds values below 1 << (8 * n). Shifting is done on u128
+                // so the 8-byte case cannot overflow, and compared in u128 for the same reason.
+                if (memory_address as u128) >= (1u128 << (8 * memory_address_length as u32))
+                    || (memory_size as u128) >= (1u128 << (8 * memory_size_length as u32))
+                {
+                    return Err(Error::IncorrectMessageLengthOrInvalidFormat);
+                }
+                Ok(Self {
+                    data_format_identifier,
+                    address_and_length_format_identifier: MemoryFormatIdentifier {
+                        memory_size_length,
+                        memory_address_length,
+                    },
                     memory_address,
                     memory_size,
                 })
@@ -372,6 +422,51 @@ macro_rules! upload_download_service {
                     assert_eq!(decoded.memory_address(), address);
                     assert_eq!(decoded.memory_size(), size);
                 }
+            }
+
+            #[test]
+            fn explicit_widths_can_reproduce_the_spec_example_alfid() {
+                // ISO 14229-1:2020 Table 441 makes the addressAndLengthFormatIdentifier a
+                // client choice, not a function of the values. Table 462's own example declares
+                // 3 bytes of memorySize for the value 0x00FFFF, which needs only 2 -- so `new`,
+                // which always derives minimal widths, cannot produce that frame. Real
+                // bootloaders commonly mandate a fixed ALFID (often 0x44) and answer
+                // requestOutOfRange otherwise.
+                let req = $req::new_with_widths(
+                    DataFormatIdentifier::from(0x11),
+                    0x0060_2000,
+                    3,
+                    0x0000_FFFF,
+                    3,
+                )
+                .unwrap();
+                let mut buf = [0u8; 16];
+                let written = Encode::encode(&req, &mut buf.as_mut_slice()).unwrap();
+                assert_eq!(
+                    &buf[..written],
+                    &[0x11, 0x33, 0x60, 0x20, 0x00, 0x00, 0xFF, 0xFF],
+                );
+
+                let decoded = <$req as Decode>::decode_exact(&buf[..written]).unwrap();
+                assert_eq!(
+                    decoded, req,
+                    "a wider-than-minimal width must survive decode"
+                );
+            }
+
+            #[test]
+            fn explicit_widths_reject_a_value_that_does_not_fit() {
+                // A declared width narrower than the value would silently truncate on the wire.
+                assert!(
+                    $req::new_with_widths(DataFormatIdentifier::NONE, 0x1_0000, 2, 1, 1).is_err()
+                );
+                assert!(
+                    $req::new_with_widths(DataFormatIdentifier::NONE, 1, 1, 0x1_0000, 2).is_err()
+                );
+                // ...and the widths themselves must be ones Table H.1 permits.
+                assert!($req::new_with_widths(DataFormatIdentifier::NONE, 1, 0, 1, 1).is_err());
+                assert!($req::new_with_widths(DataFormatIdentifier::NONE, 1, 6, 1, 1).is_err());
+                assert!($req::new_with_widths(DataFormatIdentifier::NONE, 1, 1, 1, 5).is_err());
             }
 
             #[test]

--- a/src/services/upload_download.rs
+++ b/src/services/upload_download.rs
@@ -39,6 +39,8 @@ const REQUEST_UPLOAD_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 6] = [
 macro_rules! upload_download_service {
     (
         request: $req:ident,
+        request_serde_repr: $repr:ident,
+        request_serde_repr_name: $repr_str:literal,
         response: $resp:ident,
         nrcs: $nrcs:ident,
         request_doc: $req_doc:literal,
@@ -52,7 +54,7 @@ macro_rules! upload_download_service {
         /// `address_and_length_format_identifier` value.
         /// See ISO-14229-1:2020, Table H.1 for format information.
         #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-        #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+        #[cfg_attr(feature = "serde", serde(try_from = $repr_str, into = $repr_str))]
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         #[non_exhaustive]
         pub struct $req {
@@ -179,6 +181,70 @@ macro_rules! upload_download_service {
             #[must_use]
             pub fn allowed_nack_codes() -> &'static [NegativeResponseCode] {
                 &$nrcs
+            }
+        }
+
+        #[doc = concat!("The serde/`OpenAPI` shape of [`", stringify!($req), "`].")]
+        ///
+        /// Deserializing routes through
+        #[doc = concat!("[`", stringify!($req), "::new_with_widths`],")]
+        /// so a declared width that would truncate its value is rejected rather than silently
+        /// corrupting the address on the wire, and the crate-private
+        /// `addressAndLengthFormatIdentifier` never surfaces in the serialized form.
+        #[cfg(any(feature = "serde", feature = "utoipa"))]
+        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+        struct $repr {
+            data_format_identifier: DataFormatIdentifier,
+            memory_address: u64,
+            memory_address_length: u8,
+            memory_size: u32,
+            memory_size_length: u8,
+        }
+
+        #[cfg(feature = "serde")]
+        impl TryFrom<$repr> for $req {
+            type Error = Error;
+
+            fn try_from(repr: $repr) -> Result<Self, Error> {
+                Self::new_with_widths(
+                    repr.data_format_identifier,
+                    repr.memory_address,
+                    repr.memory_address_length,
+                    repr.memory_size,
+                    repr.memory_size_length,
+                )
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl From<$req> for $repr {
+            fn from(request: $req) -> Self {
+                Self {
+                    data_format_identifier: request.data_format_identifier,
+                    memory_address: request.memory_address,
+                    memory_address_length: request
+                        .address_and_length_format_identifier
+                        .memory_address_length,
+                    memory_size: request.memory_size,
+                    memory_size_length: request
+                        .address_and_length_format_identifier
+                        .memory_size_length,
+                }
+            }
+        }
+
+        #[cfg(feature = "utoipa")]
+        impl utoipa::PartialSchema for $req {
+            fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                <$repr as utoipa::PartialSchema>::schema()
+            }
+        }
+
+        #[cfg(feature = "utoipa")]
+        impl utoipa::ToSchema for $req {
+            fn name() -> std::borrow::Cow<'static, str> {
+                std::borrow::Cow::Borrowed(stringify!($req))
             }
         }
 
@@ -573,6 +639,8 @@ macro_rules! upload_download_service {
 
 upload_download_service! {
     request: RequestDownloadRequest,
+    request_serde_repr: RequestDownloadRepr,
+    request_serde_repr_name: "RequestDownloadRepr",
     response: RequestDownloadResponse,
     nrcs: REQUEST_DOWNLOAD_NEGATIVE_RESPONSE_CODES,
     request_doc: "A request to the server for it to download data from the client.\n\nA positive response ([`RequestDownloadResponse`]) is sent once the server has taken all necessary actions and is ready to receive the data.",
@@ -583,6 +651,8 @@ upload_download_service! {
 
 upload_download_service! {
     request: RequestUploadRequest,
+    request_serde_repr: RequestUploadRepr,
+    request_serde_repr_name: "RequestUploadRepr",
     response: RequestUploadResponse,
     nrcs: REQUEST_UPLOAD_NEGATIVE_RESPONSE_CODES,
     request_doc: "A request to the server for it to upload data to the client.\n\nA positive response ([`RequestUploadResponse`]) is sent once the server is ready to transmit; the client then drives the transfer with [`TransferDataRequest`](crate::TransferDataRequest), reading the data out of each positive response, and finishes with [`RequestTransferExitRequest`](crate::RequestTransferExitRequest).",

--- a/src/services/upload_download.rs
+++ b/src/services/upload_download.rs
@@ -330,13 +330,6 @@ macro_rules! upload_download_service {
             #[doc = concat!("[`", stringify!($resp), "::new`] is fallible.")]
             #[cfg_attr(feature = "serde", serde(borrow))]
             max_number_of_block_length: &'d [u8],
-            /// The low nibble of the `lengthFormatIdentifier`, which ISO 14229-1 leaves
-            /// undefined for this byte.
-            ///
-            /// Retained from the wire so a decode/re-encode is byte-exact -- the same reason
-            /// `TesterPresentRequest` keeps a reserved sub-function value rather than
-            /// normalizing it. `0` for a response this crate constructs.
-            reserved_length_nibble: u8,
         }
 
         impl<'d> $resp<'d> {
@@ -354,7 +347,6 @@ macro_rules! upload_download_service {
                 }
                 Ok(Self {
                     max_number_of_block_length,
-                    reserved_length_nibble: 0,
                 })
             }
 
@@ -375,7 +367,6 @@ macro_rules! upload_download_service {
                 let nibble = self.max_number_of_block_length.len() as u8;
                 let length_format_identifier = LengthFormatIdentifier {
                     max_number_of_block_length: nibble,
-                    reserved_low_nibble: self.reserved_length_nibble,
                 };
                 let mut written =
                     write_u8(writer, length_format_identifier.into()).map_err(Error::io)?;
@@ -406,7 +397,6 @@ macro_rules! upload_download_service {
                 Ok((
                     Self {
                         max_number_of_block_length: &buf[1..total],
-                        reserved_length_nibble: length_format_identifier.reserved_low_nibble,
                     },
                     &buf[total..],
                 ))
@@ -603,19 +593,20 @@ macro_rules! upload_download_service {
             }
 
             #[test]
-            fn a_reserved_length_nibble_is_echoed_rather_than_zeroed() {
-                // The low nibble of the lengthFormatIdentifier is undefined in ISO 14229-1, so
-                // it is not this crate's to clear: `74 25 08 00` used to re-encode as
-                // `74 20 08 00`. That is the same loss `TesterPresentRequest` was fixed for.
-                let wire = [0x25, 0x08, 0x00];
-                let resp = <$resp as Decode>::decode_exact(&wire).unwrap();
+            fn a_reserved_length_nibble_is_zeroed_on_re_encode() {
+                // ISO 14229-1:2020 Tables 443 and 448 both give the lengthFormatIdentifier the
+                // range 0x00 to 0xF0 and state that bits 3 to 0 are "reserved by document, to be
+                // set to '0'" -- "the lower nibble shall be set to '0'". So `74 25 08 00` is a
+                // malformed byte, not a value to preserve: the block length is still read from
+                // the high nibble, but re-encoding emits the conformant `74 20 08 00`.
+                let resp = <$resp as Decode>::decode_exact(&[0x25, 0x08, 0x00]).unwrap();
                 assert_eq!(resp.max_number_of_block_length(), &[0x08, 0x00]);
 
                 let mut buf = [0u8; 8];
                 let written = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();
-                assert_eq!(&buf[..written], &wire);
+                assert_eq!(&buf[..written], &[0x20, 0x08, 0x00]);
 
-                // A response the crate builds itself leaves the nibble clear.
+                // And a response the crate builds itself encodes the same way.
                 let fresh = $resp::new(&[0x08, 0x00]).unwrap();
                 let written = Encode::encode(&fresh, &mut buf.as_mut_slice()).unwrap();
                 assert_eq!(&buf[..written], &[0x20, 0x08, 0x00]);

--- a/src/services/upload_download.rs
+++ b/src/services/upload_download.rs
@@ -194,6 +194,9 @@ macro_rules! upload_download_service {
         #[cfg(any(feature = "serde", feature = "utoipa"))]
         #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
         #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+        // With `utoipa` but not `serde` these fields are never read: they exist to give the
+        // schema its shape, which the derive reads at compile time rather than at run time.
+        #[cfg_attr(not(feature = "serde"), allow(dead_code))]
         struct $repr {
             data_format_identifier: DataFormatIdentifier,
             memory_address: u64,

--- a/src/services/upload_download.rs
+++ b/src/services/upload_download.rs
@@ -199,12 +199,9 @@ macro_rules! upload_download_service {
         /// utoipa's derive reads only literal doc attributes, so a `#[doc = concat!(..)]` naming
         /// the specific service is dropped from the schema -- which is what left this description
         /// missing its verb.
-        #[cfg(any(feature = "serde", feature = "utoipa"))]
+        #[cfg(feature = "serde")]
         #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
         #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-        // With `utoipa` but not `serde` these fields are never read: they exist to give the
-        // schema its shape, which the derive reads at compile time rather than at run time.
-        #[cfg_attr(not(feature = "serde"), allow(dead_code))]
         struct $repr {
             data_format_identifier: DataFormatIdentifier,
             memory_address: u64,

--- a/src/services/upload_download.rs
+++ b/src/services/upload_download.rs
@@ -47,6 +47,7 @@ macro_rules! upload_download_service {
         nrcs: $nrcs:ident,
         request_doc: $req_doc:literal,
         response_doc: $resp_doc:literal,
+        block_length_accessor_doc: $block_accessor_doc:literal,
         verb: $verb:literal,
         tests: $test_mod:ident,
     ) => {
@@ -341,7 +342,8 @@ macro_rules! upload_download_service {
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         #[non_exhaustive]
         pub struct $resp<'d> {
-            /// Maximum number of bytes per [`TransferDataRequest`](crate::TransferDataRequest).
+            /// The `maxNumberOfBlockLength` bytes, as sent. See the accessor of the same name for
+            /// what the value means for this service -- it differs between download and upload.
             ///
             /// The on-wire `lengthFormatIdentifier` nibble is derived from this slice's length,
             /// so the declared length can never disagree with the bytes present. That nibble
@@ -369,8 +371,10 @@ macro_rules! upload_download_service {
                 })
             }
 
-            /// The maximum number of bytes the server will accept per `TransferData` request,
-            /// as the raw big-endian bytes the server sent.
+            #[doc = $block_accessor_doc]
+            ///
+            /// The raw big-endian bytes the server sent, so a value wider than `u64` is not
+            /// truncated. Its length is the `lengthFormatIdentifier` nibble, at most 15 bytes.
             #[must_use]
             pub const fn max_number_of_block_length(&self) -> &'d [u8] {
                 self.max_number_of_block_length
@@ -740,6 +744,7 @@ upload_download_service! {
     nrcs: REQUEST_DOWNLOAD_NEGATIVE_RESPONSE_CODES,
     request_doc: "A request to the server for it to download data from the client.\n\nA positive response ([`RequestDownloadResponse`]) is sent once the server has taken all necessary actions and is ready to receive the data.",
     response_doc: "Zero-alloc positive response to a [`RequestDownloadRequest`], indicating the server is ready to receive data. Borrows from the caller.",
+    block_length_accessor_doc: "How many bytes to put in each [`TransferDataRequest`](crate::TransferDataRequest), including its service identifier and data parameters.\n\nThis is the server\u{2019}s **receive** buffer size, so it constrains what the *client sends*. ISO 14229-1:2020 Table 443: the server \"is required to accept transferData requests that are equal in length to its reported maxNumberOfBlockLength\", and it is server-specific whether shorter ones are accepted at all. The last request in a block may have to be shorter.\n\nTable 443 also forbids a server from writing pad bytes that were not in the `TransferData` message, since that would shift the memory address the next request writes to.",
     verb: "downloaded",
     tests: request_download_tests,
 }
@@ -752,6 +757,7 @@ upload_download_service! {
     nrcs: REQUEST_UPLOAD_NEGATIVE_RESPONSE_CODES,
     request_doc: "A request to the server for it to upload data to the client.\n\nA positive response ([`RequestUploadResponse`]) is sent once the server is ready to transmit; the client then drives the transfer with [`TransferDataRequest`](crate::TransferDataRequest), reading the data out of each positive response, and finishes with [`RequestTransferExitRequest`](crate::RequestTransferExitRequest).",
     response_doc: "Zero-alloc positive response to a [`RequestUploadRequest`], indicating the server is ready to transmit data. Borrows from the caller.",
+    block_length_accessor_doc: "How many bytes the server will put in each [`TransferDataResponse`](crate::TransferDataResponse), including its service identifier and data parameters.\n\nNote the direction. Despite sharing a name with [`RequestDownloadResponse::max_number_of_block_length`](crate::RequestDownloadResponse::max_number_of_block_length), this constrains the *server\u{2019}s responses* rather than the client\u{2019}s requests, and reports the server\u{2019}s **send** buffer rather than its receive buffer. ISO 14229-1:2020 Table 448 also puts the obligation on the other party: the *client* \"is required to accept transferData responses that are equal in length to the reported maxNumberOfBlockLength\", and it is server-specific whether any shorter ones are sent. The last response in a block may be shorter.\n\nTable 448 states no pad-byte prohibition; that is the download side\u{2019}s concern, because nothing here is written to server memory.",
     verb: "uploaded",
     tests: request_upload_tests,
 }

--- a/src/services/upload_download.rs
+++ b/src/services/upload_download.rs
@@ -187,13 +187,18 @@ macro_rules! upload_download_service {
             }
         }
 
-        #[doc = concat!("The serde/`OpenAPI` shape of [`", stringify!($req), "`].")]
+        /// A transfer-setup request: a data-format identifier, a memory address and a memory
+        /// size, plus the byte width each of the latter two is declared with on the wire.
         ///
-        /// Deserializing routes through
-        #[doc = concat!("[`", stringify!($req), "::new_with_widths`],")]
-        /// so a declared width that would truncate its value is rejected rather than silently
-        /// corrupting the address on the wire, and the crate-private
-        /// `addressAndLengthFormatIdentifier` never surfaces in the serialized form.
+        /// A width that would truncate its value is rejected rather than silently corrupting the
+        /// address on the wire, and the crate-private `addressAndLengthFormatIdentifier` that
+        /// packs the two widths never surfaces here.
+        ///
+        /// This doc comment is the published schema description for the request type, because its
+        /// hand-written `PartialSchema` delegates here. It deliberately uses plain `///` lines:
+        /// utoipa's derive reads only literal doc attributes, so a `#[doc = concat!(..)]` naming
+        /// the specific service is dropped from the schema -- which is what left this description
+        /// missing its verb.
         #[cfg(any(feature = "serde", feature = "utoipa"))]
         #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
         #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -251,6 +256,17 @@ macro_rules! upload_download_service {
         impl utoipa::ToSchema for $req {
             fn name() -> std::borrow::Cow<'static, str> {
                 std::borrow::Cow::Borrowed(stringify!($req))
+            }
+
+            /// See the note on `CommunicationControlRequest::schemas`: a hand-written `ToSchema`
+            /// must forward this or its `$ref`s dangle.
+            fn schemas(
+                schemas: &mut Vec<(
+                    String,
+                    utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+                )>,
+            ) {
+                <$repr as utoipa::ToSchema>::schemas(schemas);
             }
         }
 

--- a/src/services/upload_download.rs
+++ b/src/services/upload_download.rs
@@ -14,6 +14,9 @@ use crate::shared::{
 use crate::{Decode, Encode, Error, Incomplete, NegativeResponseCode};
 use automotive_wire_codec::{read_be_uint_into, write_all, write_be_uint, write_u8};
 
+/// Widest `maxNumberOfBlockLength` a `lengthFormatIdentifier` nibble can declare, in bytes.
+const MAX_BLOCK_LENGTH_BYTES: usize = 0x0F;
+
 /// Permitted NRCs for `RequestDownload` (0x34).
 const REQUEST_DOWNLOAD_NEGATIVE_RESPONSE_CODES: [NegativeResponseCode; 6] = [
     NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat,
@@ -321,20 +324,45 @@ macro_rules! upload_download_service {
         pub struct $resp<'d> {
             /// Maximum number of bytes per [`TransferDataRequest`](crate::TransferDataRequest).
             ///
-            /// The on-wire `lengthFormatIdentifier` nibble is derived from this slice's length
-            /// at encode time, so the declared length can never disagree with the bytes present.
+            /// The on-wire `lengthFormatIdentifier` nibble is derived from this slice's length,
+            /// so the declared length can never disagree with the bytes present. That nibble
+            /// holds at most `0x0F`, which is why the slice is private and
+            #[doc = concat!("[`", stringify!($resp), "::new`] is fallible.")]
             #[cfg_attr(feature = "serde", serde(borrow))]
-            pub max_number_of_block_length: &'d [u8],
+            max_number_of_block_length: &'d [u8],
+            /// The low nibble of the `lengthFormatIdentifier`, which ISO 14229-1 leaves
+            /// undefined for this byte.
+            ///
+            /// Retained from the wire so a decode/re-encode is byte-exact -- the same reason
+            /// `TesterPresentRequest` keeps a reserved sub-function value rather than
+            /// normalizing it. `0` for a response this crate constructs.
+            reserved_length_nibble: u8,
         }
 
         impl<'d> $resp<'d> {
             #[doc = concat!("Create a new `", stringify!($resp), "`. The `lengthFormatIdentifier`")]
             /// is derived from `max_number_of_block_length` during encoding.
-            #[must_use]
-            pub const fn new(max_number_of_block_length: &'d [u8]) -> Self {
-                Self {
-                    max_number_of_block_length,
+            ///
+            /// # Errors
+            /// Returns [`Error::IncorrectMessageLengthOrInvalidFormat`] if the slice is longer
+            /// than 15 bytes, which is the widest a single nibble can declare. The check used to
+            /// live in `encode`, so a too-long slice was accepted here and failed later — the
+            /// same construct-then-fail-to-encode asymmetry the transfer requests had.
+            pub const fn new(max_number_of_block_length: &'d [u8]) -> Result<Self, Error> {
+                if max_number_of_block_length.len() > MAX_BLOCK_LENGTH_BYTES {
+                    return Err(Error::IncorrectMessageLengthOrInvalidFormat);
                 }
+                Ok(Self {
+                    max_number_of_block_length,
+                    reserved_length_nibble: 0,
+                })
+            }
+
+            /// The maximum number of bytes the server will accept per `TransferData` request,
+            /// as the raw big-endian bytes the server sent.
+            #[must_use]
+            pub const fn max_number_of_block_length(&self) -> &'d [u8] {
+                self.max_number_of_block_length
             }
         }
 
@@ -342,14 +370,12 @@ macro_rules! upload_download_service {
             type Error = crate::Error;
 
             fn encode(&self, writer: &mut impl embedded_io::Write) -> Result<usize, Error> {
-                // The block-length field width is carried in a single nibble, so the slice
-                // can be at most 0x0F bytes long.
-                let nibble = u8::try_from(self.max_number_of_block_length.len())
-                    .ok()
-                    .filter(|n| *n <= 0x0F)
-                    .ok_or(Error::IncorrectMessageLengthOrInvalidFormat)?;
+                // `new` already bounded this to a nibble, so the cast cannot truncate.
+                #[allow(clippy::cast_possible_truncation)]
+                let nibble = self.max_number_of_block_length.len() as u8;
                 let length_format_identifier = LengthFormatIdentifier {
                     max_number_of_block_length: nibble,
+                    reserved_low_nibble: self.reserved_length_nibble,
                 };
                 let mut written =
                     write_u8(writer, length_format_identifier.into()).map_err(Error::io)?;
@@ -380,6 +406,7 @@ macro_rules! upload_download_service {
                 Ok((
                     Self {
                         max_number_of_block_length: &buf[1..total],
+                        reserved_length_nibble: length_format_identifier.reserved_low_nibble,
                     },
                     &buf[total..],
                 ))
@@ -571,20 +598,45 @@ macro_rules! upload_download_service {
             #[test]
             fn response_encode_size_agrees() {
                 let block = [0x10u8, 0x00, 0x00];
-                let resp = $resp::new(&block);
+                let resp = $resp::new(&block).unwrap();
                 assert_encode_size_agrees(&resp);
+            }
+
+            #[test]
+            fn a_reserved_length_nibble_is_echoed_rather_than_zeroed() {
+                // The low nibble of the lengthFormatIdentifier is undefined in ISO 14229-1, so
+                // it is not this crate's to clear: `74 25 08 00` used to re-encode as
+                // `74 20 08 00`. That is the same loss `TesterPresentRequest` was fixed for.
+                let wire = [0x25, 0x08, 0x00];
+                let resp = <$resp as Decode>::decode_exact(&wire).unwrap();
+                assert_eq!(resp.max_number_of_block_length(), &[0x08, 0x00]);
+
+                let mut buf = [0u8; 8];
+                let written = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();
+                assert_eq!(&buf[..written], &wire);
+
+                // A response the crate builds itself leaves the nibble clear.
+                let fresh = $resp::new(&[0x08, 0x00]).unwrap();
+                let written = Encode::encode(&fresh, &mut buf.as_mut_slice()).unwrap();
+                assert_eq!(&buf[..written], &[0x20, 0x08, 0x00]);
+            }
+
+            #[test]
+            fn a_block_length_wider_than_a_nibble_is_rejected_at_construction() {
+                assert!($resp::new(&[0u8; 16]).is_err());
+                assert!($resp::new(&[0u8; 15]).is_ok());
             }
 
             #[test]
             fn response_round_trips() {
                 let block = [0x02u8, 0x00];
-                let resp = $resp::new(&block);
+                let resp = $resp::new(&block).unwrap();
                 let mut buf = [0u8; 8];
                 let n = Encode::encode(&resp, &mut buf.as_mut_slice()).unwrap();
                 assert_eq!(&buf[..n], &[0x20, 0x02, 0x00]);
                 let (decoded, rest) = <$resp as Decode>::decode(&buf[..n]).unwrap();
                 assert!(rest.is_empty());
-                assert_eq!(decoded.max_number_of_block_length, &block);
+                assert_eq!(decoded.max_number_of_block_length(), &block);
             }
 
             #[test]

--- a/src/services/upload_download.rs
+++ b/src/services/upload_download.rs
@@ -8,8 +8,7 @@
 //! truth; a fix to the width-derivation logic cannot land on one service and miss the other.
 
 use crate::shared::{
-    DataFormatIdentifier, LengthFormatIdentifier, MAX_MEMORY_ADDRESS_LENGTH,
-    MAX_MEMORY_SIZE_LENGTH, MemoryFormatIdentifier,
+    AddressAndLengthFormatIdentifier, DataFormatIdentifier, LengthFormatIdentifier,
 };
 use crate::{Decode, Encode, Error, Incomplete, NegativeResponseCode};
 use automotive_wire_codec::{read_be_uint_into, write_all, write_be_uint, write_u8};
@@ -66,7 +65,7 @@ macro_rules! upload_download_service {
             data_format_identifier: DataFormatIdentifier,
             /// 7-4: length (# of bytes) of `memory_size` param, 3-0: length (# of bytes) of
             /// `memory_address` param
-            address_and_length_format_identifier: MemoryFormatIdentifier,
+            address_and_length_format_identifier: AddressAndLengthFormatIdentifier,
             /// Starting address of the server memory. The on-wire byte width is derived from
             /// this value (max 5 bytes), so it is private to keep it in sync with the format
             /// identifier.
@@ -78,10 +77,17 @@ macro_rules! upload_download_service {
         }
 
         impl $req {
-            #[doc = concat!("Create a new `", stringify!($req), "`")]
+            #[doc = concat!("Create a new `", stringify!($req), "` with the narrowest widths that")]
+            /// hold the given values.
+            ///
+            /// This is the common case. Use
+            #[doc = concat!("[`new_with_alfid`](", stringify!($req), "::new_with_alfid)")]
+            /// when the server mandates a particular `addressAndLengthFormatIdentifier`.
             ///
             /// # Errors
-            /// Returns an error if `memory_address` exceeds 5 bytes (> `0xFF_FFFF_FFFF`).
+            /// Returns [`Error::InvalidMemoryAddress`] if `memory_address` needs more than the
+            /// 5 bytes the format identifier's low nibble can declare (i.e. exceeds
+            /// `0xFF_FFFF_FFFF`). `memory_size` is a `u32`, so it always fits four.
             #[allow(clippy::cast_possible_truncation)]
             pub const fn new(
                 data_format_identifier: DataFormatIdentifier,
@@ -91,71 +97,76 @@ macro_rules! upload_download_service {
                 if memory_address > 0xFF_FFFF_FFFF {
                     return Err(Error::InvalidMemoryAddress(memory_address));
                 }
-                // A length of 0 produces an invalid `MemoryFormatIdentifier` (the nibbles
-                // must be >=1 per ISO-14229), so clamp to at least one byte even when the
-                // address or size is 0. Written as `if` rather than `.max(1)` because
-                // `Ord::max` is not callable in a `const fn`.
+                // A width of 0 is "not applicable" in Table H.1, so clamp to one byte even when
+                // the value is 0. Written as `if` rather than `.max(1)` because `Ord::max` is not
+                // callable in a `const fn`.
                 let address_bytes = (u64::BITS - memory_address.leading_zeros()).div_ceil(8) as u8;
                 let memory_address_length = if address_bytes == 0 { 1 } else { address_bytes };
                 let size_bytes = (u32::BITS - memory_size.leading_zeros()).div_ceil(8) as u8;
                 let memory_size_length = if size_bytes == 0 { 1 } else { size_bytes };
-                let address_and_length_format_identifier = MemoryFormatIdentifier {
+                // Delegate rather than build the value here, so there is exactly one path that
+                // decides whether a (value, width) pair is acceptable. These two used to be
+                // independent, and disagreed: the same over-wide address produced
+                // `InvalidMemoryAddress` from one and `IncorrectMessageLengthOrInvalidFormat`
+                // from the other, i.e. NRC 0x31 versus 0x13 for one input.
+                match AddressAndLengthFormatIdentifier::new(
                     memory_size_length,
                     memory_address_length,
-                };
+                ) {
+                    Ok(alfid) => Self::new_with_alfid(
+                        data_format_identifier,
+                        alfid,
+                        memory_address,
+                        memory_size,
+                    ),
+                    Err(e) => Err(e),
+                }
+            }
+
+            #[doc = concat!("Create a `", stringify!($req), "` with a caller-chosen")]
+            /// `addressAndLengthFormatIdentifier`.
+            ///
+            /// ISO 14229-1:2020 Table 441 makes the format identifier a client choice rather than
+            /// a function of the values, and clause 11.3.1 blesses "a **fixed**
+            /// addressAndLengthFormatIdentifier" with the unused bytes "padded with the value
+            /// 0x00". The standard's own examples are non-minimal — Table 462 declares three
+            /// `memorySize` bytes for `0x00FFFF`, which needs two — so [`new`](Self::new), which
+            /// always derives the narrowest widths, cannot reproduce them. This can.
+            ///
+            /// # Errors
+            /// Returns [`Error::InvalidMemoryAddress`] or [`Error::InvalidMemorySize`] if the
+            /// value does not fit the width `alfid` declares for it, which would otherwise
+            /// truncate it on the wire. Both map to NRC `0x31`, as Tables 444 and 449 require for
+            /// a `memoryAddress`/`memorySize` that "is not valid".
+            pub const fn new_with_alfid(
+                data_format_identifier: DataFormatIdentifier,
+                alfid: AddressAndLengthFormatIdentifier,
+                memory_address: u64,
+                memory_size: u32,
+            ) -> Result<Self, Error> {
+                // A width of n bytes holds values below 1 << (8 * n). Shifted and compared as
+                // u128 so the widest case cannot overflow.
+                if (memory_address as u128) >= (1u128 << (8 * alfid.memory_address_length() as u32))
+                {
+                    return Err(Error::InvalidMemoryAddress(memory_address));
+                }
+                if (memory_size as u128) >= (1u128 << (8 * alfid.memory_size_length() as u32)) {
+                    return Err(Error::InvalidMemorySize(memory_size));
+                }
                 Ok(Self {
                     data_format_identifier,
-                    address_and_length_format_identifier,
+                    address_and_length_format_identifier: alfid,
                     memory_address,
                     memory_size,
                 })
             }
 
-            #[doc = concat!("Create a `", stringify!($req), "` with client-chosen field widths.")]
-            ///
-            /// ISO 14229-1:2020 Table 441 makes the `addressAndLengthFormatIdentifier` a
-            /// client choice rather than a function of the values, and many bootloaders
-            /// require a particular one (often `0x44`) and answer `requestOutOfRange`
-            /// otherwise. [`new`](Self::new) always derives the *minimal* widths, so it cannot
-            /// express a wider-than-minimal declaration; this can.
-            ///
-            /// Widths are in bytes: `memory_address_length` may be 1 through 5 and
-            /// `memory_size_length` 1 through 4 (Annex H Table H.1).
-            ///
-            /// # Errors
-            /// Returns [`Error::IncorrectMessageLengthOrInvalidFormat`] if either width is
-            /// outside the range Table H.1 permits, or if a value does not fit in the width
-            /// declared for it — which would otherwise truncate it on the wire.
-            pub const fn new_with_widths(
-                data_format_identifier: DataFormatIdentifier,
-                memory_address: u64,
-                memory_address_length: u8,
-                memory_size: u32,
-                memory_size_length: u8,
-            ) -> Result<Self, Error> {
-                if memory_address_length < 1
-                    || memory_address_length > MAX_MEMORY_ADDRESS_LENGTH
-                    || memory_size_length < 1
-                    || memory_size_length > MAX_MEMORY_SIZE_LENGTH
-                {
-                    return Err(Error::IncorrectMessageLengthOrInvalidFormat);
-                }
-                // A width of n bytes holds values below 1 << (8 * n). Shifting is done on u128
-                // so the 8-byte case cannot overflow, and compared in u128 for the same reason.
-                if (memory_address as u128) >= (1u128 << (8 * memory_address_length as u32))
-                    || (memory_size as u128) >= (1u128 << (8 * memory_size_length as u32))
-                {
-                    return Err(Error::IncorrectMessageLengthOrInvalidFormat);
-                }
-                Ok(Self {
-                    data_format_identifier,
-                    address_and_length_format_identifier: MemoryFormatIdentifier {
-                        memory_size_length,
-                        memory_address_length,
-                    },
-                    memory_address,
-                    memory_size,
-                })
+            /// The widths this request declares for `memoryAddress` and `memorySize`.
+            #[must_use]
+            pub const fn address_and_length_format_identifier(
+                &self,
+            ) -> AddressAndLengthFormatIdentifier {
+                self.address_and_length_format_identifier
             }
 
             /// The compression and encryption methods the client asked the server to use.
@@ -204,10 +215,9 @@ macro_rules! upload_download_service {
         #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
         struct $repr {
             data_format_identifier: DataFormatIdentifier,
+            address_and_length_format_identifier: AddressAndLengthFormatIdentifier,
             memory_address: u64,
-            memory_address_length: u8,
             memory_size: u32,
-            memory_size_length: u8,
         }
 
         #[cfg(feature = "serde")]
@@ -215,12 +225,11 @@ macro_rules! upload_download_service {
             type Error = Error;
 
             fn try_from(repr: $repr) -> Result<Self, Error> {
-                Self::new_with_widths(
+                Self::new_with_alfid(
                     repr.data_format_identifier,
+                    repr.address_and_length_format_identifier,
                     repr.memory_address,
-                    repr.memory_address_length,
                     repr.memory_size,
-                    repr.memory_size_length,
                 )
             }
         }
@@ -230,14 +239,10 @@ macro_rules! upload_download_service {
             fn from(request: $req) -> Self {
                 Self {
                     data_format_identifier: request.data_format_identifier,
+                    address_and_length_format_identifier: request
+                        .address_and_length_format_identifier,
                     memory_address: request.memory_address,
-                    memory_address_length: request
-                        .address_and_length_format_identifier
-                        .memory_address_length,
                     memory_size: request.memory_size,
-                    memory_size_length: request
-                        .address_and_length_format_identifier
-                        .memory_size_length,
                 }
             }
         }
@@ -282,9 +287,10 @@ macro_rules! upload_download_service {
 
                 let addr_len = self
                     .address_and_length_format_identifier
-                    .memory_address_length as usize;
-                let size_len =
-                    self.address_and_length_format_identifier.memory_size_length as usize;
+                    .memory_address_length() as usize;
+                let size_len = self
+                    .address_and_length_format_identifier
+                    .memory_size_length() as usize;
                 written += write_be_uint(writer, u128::from(self.memory_address), addr_len)?;
                 written += write_be_uint(writer, u128::from(self.memory_size), size_len)?;
 
@@ -303,9 +309,9 @@ macro_rules! upload_download_service {
                     }));
                 }
                 let data_format_identifier = DataFormatIdentifier::from(buf[0]);
-                let memory_identifier = MemoryFormatIdentifier::try_from(buf[1])?;
-                let addr_len = memory_identifier.memory_address_length as usize;
-                let size_len = memory_identifier.memory_size_length as usize;
+                let memory_identifier = AddressAndLengthFormatIdentifier::try_from(buf[1])?;
+                let addr_len = memory_identifier.memory_address_length() as usize;
+                let size_len = memory_identifier.memory_size_length() as usize;
                 let total = 2 + addr_len + size_len;
                 if buf.len() < total {
                     return Err(Error::InsufficientData(Incomplete {
@@ -435,12 +441,12 @@ macro_rules! upload_download_service {
                 assert_eq!(u8::from(req.data_format_identifier), 0);
                 assert_eq!(u8::from(req.address_and_length_format_identifier), 0x14);
                 assert_eq!(
-                    req.address_and_length_format_identifier.memory_size_length,
+                    req.address_and_length_format_identifier.memory_size_length(),
                     1
                 );
                 assert_eq!(
                     req.address_and_length_format_identifier
-                        .memory_address_length,
+                        .memory_address_length(),
                     4
                 );
 
@@ -466,11 +472,11 @@ macro_rules! upload_download_service {
                 let req = $req::new(0x00.into(), 0, 0).unwrap();
                 assert_eq!(
                     req.address_and_length_format_identifier
-                        .memory_address_length,
+                        .memory_address_length(),
                     1
                 );
                 assert_eq!(
-                    req.address_and_length_format_identifier.memory_size_length,
+                    req.address_and_length_format_identifier.memory_size_length(),
                     1
                 );
 
@@ -531,12 +537,11 @@ macro_rules! upload_download_service {
                 // which always derives minimal widths, cannot produce that frame. Real
                 // bootloaders commonly mandate a fixed ALFID (often 0x44) and answer
                 // requestOutOfRange otherwise.
-                let req = $req::new_with_widths(
+                let req = $req::new_with_alfid(
                     DataFormatIdentifier::from(0x11),
+                    AddressAndLengthFormatIdentifier::new(3, 3).unwrap(),
                     0x0060_2000,
-                    3,
                     0x0000_FFFF,
-                    3,
                 )
                 .unwrap();
                 let mut buf = [0u8; 16];
@@ -556,16 +561,47 @@ macro_rules! upload_download_service {
             #[test]
             fn explicit_widths_reject_a_value_that_does_not_fit() {
                 // A declared width narrower than the value would silently truncate on the wire.
-                assert!(
-                    $req::new_with_widths(DataFormatIdentifier::NONE, 0x1_0000, 2, 1, 1).is_err()
-                );
-                assert!(
-                    $req::new_with_widths(DataFormatIdentifier::NONE, 1, 1, 0x1_0000, 2).is_err()
-                );
-                // ...and the widths themselves must be ones Table H.1 permits.
-                assert!($req::new_with_widths(DataFormatIdentifier::NONE, 1, 0, 1, 1).is_err());
-                assert!($req::new_with_widths(DataFormatIdentifier::NONE, 1, 6, 1, 1).is_err());
-                assert!($req::new_with_widths(DataFormatIdentifier::NONE, 1, 1, 1, 5).is_err());
+                // Both of these are NRC 0x31 per Tables 444 and 449, and they name which
+                // parameter was at fault rather than collapsing to one length error.
+                let two_byte_address = AddressAndLengthFormatIdentifier::new(1, 2).unwrap();
+                assert!(matches!(
+                    $req::new_with_alfid(
+                        DataFormatIdentifier::NONE,
+                        two_byte_address,
+                        0x1_0000,
+                        1
+                    ),
+                    Err(Error::InvalidMemoryAddress(0x1_0000))
+                ));
+                let two_byte_size = AddressAndLengthFormatIdentifier::new(2, 1).unwrap();
+                assert!(matches!(
+                    $req::new_with_alfid(DataFormatIdentifier::NONE, two_byte_size, 1, 0x1_0000),
+                    Err(Error::InvalidMemorySize(0x1_0000))
+                ));
+
+                // ...and the widths themselves must be ones Table H.1 permits. That check now
+                // lives on the format identifier, so it cannot be reached with a bad width.
+                assert!(AddressAndLengthFormatIdentifier::new(1, 0).is_err());
+                assert!(AddressAndLengthFormatIdentifier::new(1, 6).is_err());
+                assert!(AddressAndLengthFormatIdentifier::new(5, 1).is_err());
+            }
+
+            #[test]
+            fn both_constructors_reject_an_over_wide_address_the_same_way() {
+                // These were independent code paths that disagreed: the same over-wide address
+                // produced InvalidMemoryAddress from `new` and IncorrectMessageLengthOrInvalidFormat
+                // from the explicit-width constructor -- NRC 0x31 versus 0x13 for one input.
+                // `new` now derives its widths and delegates, so there is one decision.
+                let too_wide = 0x1_0000_0000_0000u64;
+                let widest = AddressAndLengthFormatIdentifier::new(4, 5).unwrap();
+                assert!(matches!(
+                    $req::new(DataFormatIdentifier::NONE, too_wide, 0x10),
+                    Err(Error::InvalidMemoryAddress(a)) if a == too_wide
+                ));
+                assert!(matches!(
+                    $req::new_with_alfid(DataFormatIdentifier::NONE, widest, too_wide, 0x10),
+                    Err(Error::InvalidMemoryAddress(a)) if a == too_wide
+                ));
             }
 
             #[test]

--- a/src/services/write_data_by_identifier.rs
+++ b/src/services/write_data_by_identifier.rs
@@ -25,8 +25,15 @@ pub struct WriteDataByIdentifierRequest<'d> {
     /// the big-endian encoding is handled on the wire.
     pub identifier: u16,
     /// The opaque data record written after the identifier.
-    #[cfg_attr(feature = "serde", serde(borrow))]
-    pub data: &'d [u8],
+    ///
+    /// Private because it carries an invariant: ISO 14229-1:2020 Table 277 marks `dataRecord`
+    /// byte #1 mandatory, so an empty record encodes to a frame this crate's own decoder
+    /// rejects. Read it back with [`WriteDataByIdentifierRequest::data`].
+    #[cfg_attr(
+        feature = "serde",
+        serde(borrow, deserialize_with = "crate::shared::bounded::non_empty_bytes")
+    )]
+    data: &'d [u8],
 }
 
 impl<'d> WriteDataByIdentifierRequest<'d> {
@@ -42,6 +49,12 @@ impl<'d> WriteDataByIdentifierRequest<'d> {
             return Err(Error::IncorrectMessageLengthOrInvalidFormat);
         }
         Ok(Self { identifier, data })
+    }
+
+    /// The opaque data record written after the identifier. Never empty.
+    #[must_use]
+    pub const fn data(&self) -> &'d [u8] {
+        self.data
     }
 
     /// Get the allowed [`NegativeResponseCode`] variants for this request.

--- a/src/shared/bounded.rs
+++ b/src/shared/bounded.rs
@@ -1,0 +1,60 @@
+//! `serde` field validators for the borrowed fields that carry a length invariant.
+//!
+//! A few request and response fields are length-bounded because the wire field that declares
+//! their length is one or two bytes wide, or because ISO marks the first byte mandatory. Their
+//! constructors enforce that, but `derive(Deserialize)` ignores constructors — so without these,
+//! deserializing is a second way in that produces a value `encode` rejects, or worse, one that
+//! encodes to a frame this crate's own decoder refuses.
+//!
+//! These are field-level `deserialize_with` hooks rather than whole-type mirror structs: every
+//! invariant here is a property of a single field, so there is nothing for an aggregate to
+//! coordinate. Two mirror structs were used for a single-field invariant elsewhere in this crate
+//! and cost about a hundred lines to say what one attribute says.
+
+use serde::{Deserialize, Deserializer, de::Error as _};
+
+/// Deserialize a byte slice that must not be empty.
+///
+/// ISO 14229-1:2020 Table 277 marks `dataRecord` byte #1 mandatory for `WriteDataByIdentifier`,
+/// and Figure 26 states a four-byte minimum frame, so an empty record encodes to a message the
+/// decoder answers NRC 0x13 to.
+pub(crate) fn non_empty_bytes<'de, D>(deserializer: D) -> Result<&'de [u8], D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let bytes = <&'de [u8]>::deserialize(deserializer)?;
+    if bytes.is_empty() {
+        return Err(D::Error::custom(
+            "the data record must contain at least one byte",
+        ));
+    }
+    Ok(bytes)
+}
+
+/// Deserialize a byte slice whose length must fit the one-byte field that declares it.
+pub(crate) fn bytes_within_u8_len<'de, D>(deserializer: D) -> Result<&'de [u8], D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let bytes = <&'de [u8]>::deserialize(deserializer)?;
+    if bytes.len() > u8::MAX as usize {
+        return Err(D::Error::custom(
+            "maxNumberOfBlockLength is longer than the one-byte length field can declare",
+        ));
+    }
+    Ok(bytes)
+}
+
+/// Deserialize a string whose length must fit the two-byte field that declares it.
+pub(crate) fn str_within_u16_len<'de, D>(deserializer: D) -> Result<&'de str, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let text = <&'de str>::deserialize(deserializer)?;
+    if text.len() > u16::MAX as usize {
+        return Err(D::Error::custom(
+            "filePathAndName is longer than the two-byte length field can declare",
+        ));
+    }
+    Ok(text)
+}

--- a/src/shared/byte_schema.rs
+++ b/src/shared/byte_schema.rs
@@ -28,7 +28,10 @@ macro_rules! byte_schema {
 byte_schema!(
     CommunicationControlType,
     DataFormatIdentifier,
+    DtcFormatIdentifier,
     DtcSettingType,
+    FileOperationMode,
+    FunctionalGroupIdentifier,
     SecurityAccessType,
     SubnetNumber,
 );

--- a/src/shared/byte_schema.rs
+++ b/src/shared/byte_schema.rs
@@ -44,6 +44,15 @@ macro_rules! byte_schema {
 }
 
 byte_schema!(
+    AddressAndLengthFormatIdentifier {
+        max: 0x45u8,
+        description: "An addressAndLengthFormatIdentifier byte: memorySize width in the high \
+                      nibble (1 to 4 bytes), memoryAddress width in the low nibble (1 to 5). So \
+                      0x44 declares four bytes each. ISO 14229-1:2020 Annex H Table H.1 runs \
+                      from 0x11 to 0x45 and marks a zero nibble, or a size above 4, \
+                      not applicable. The accepted set is not contiguous: 0x15, 0x25, 0x35 and \
+                      0x40 to 0x43 fall inside these bounds but are rejected."
+    },
     CommunicationControlType {
         max: 0x7Fu8,
         description: "A CommunicationControl sub-function byte, 0x00 to 0x7F. Bit 7 is the \

--- a/src/shared/byte_schema.rs
+++ b/src/shared/byte_schema.rs
@@ -1,18 +1,36 @@
 //! `OpenAPI` schemas for the types that serialize as a single protocol byte.
 //!
 //! Several public types are one wire byte with a range invariant. Their `serde` impls go
-//! through `u8` (via `serde(try_from = "u8", into = "u8")`) so that deserializing cannot build a
-//! value their constructor would reject. A derived `ToSchema` would still describe the Rust
-//! shape — an object with nibble properties, or a `oneOf` over variant names — and so disagree
-//! with what `serde` actually reads and writes. These impls keep the two in step.
+//! through `u8` (via `serde(try_from = "u8", into = "u8")` or `serde(from = "u8", into = "u8")`)
+//! so that deserializing cannot build a value their constructor would reject. A derived
+//! `ToSchema` would still describe the Rust shape — an object with nibble properties, or a
+//! `oneOf` over variant names — and so disagree with what `serde` actually reads and writes.
+//! These impls keep the two in step.
+//!
+//! Each schema carries the actual accepted range rather than `u8`'s bare
+//! `{"type": "integer", "minimum": 0}`. Delegating to `<u8 as PartialSchema>` advertised
+//! `0..=2^31`, so a generated client emitted an `i32` and discovered the real bound as a runtime
+//! rejection. The whole reason these types exist is that their bytes have ranges; the schema is
+//! the one place that has to say so.
 
-/// Implement `PartialSchema`/`ToSchema` for types whose serialized form is a `u8`.
+/// Implement `PartialSchema`/`ToSchema` for a type whose serialized form is a single `u8`.
+///
+/// `max` is the largest byte the type's own `serde` entry point accepts, so the schema and the
+/// deserializer cannot drift; `description` is the published schema description and must spell out
+/// any gaps, because `minimum`/`maximum` alone cannot express a non-contiguous set.
 macro_rules! byte_schema {
-    ($($ty:ident),* $(,)?) => {
+    ($($ty:ident { max: $max:expr, description: $desc:literal }),* $(,)?) => {
         $(
             impl utoipa::PartialSchema for crate::$ty {
                 fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-                    <u8 as utoipa::PartialSchema>::schema()
+                    utoipa::openapi::ObjectBuilder::new()
+                        .schema_type(utoipa::openapi::schema::SchemaType::Type(
+                            utoipa::openapi::Type::Integer,
+                        ))
+                        .minimum(Some(0.0))
+                        .maximum(Some(f64::from($max)))
+                        .description(Some($desc))
+                        .into()
                 }
             }
 
@@ -26,12 +44,57 @@ macro_rules! byte_schema {
 }
 
 byte_schema!(
-    CommunicationControlType,
-    DataFormatIdentifier,
-    DtcFormatIdentifier,
-    DtcSettingType,
-    FileOperationMode,
-    FunctionalGroupIdentifier,
-    SecurityAccessType,
-    SubnetNumber,
+    CommunicationControlType {
+        max: 0x7Fu8,
+        description: "A CommunicationControl sub-function byte, 0x00 to 0x7F. Bit 7 is the \
+                      suppressPosRspMsgIndicationBit and is carried separately, so a value with \
+                      it set is rejected."
+    },
+    DataFormatIdentifier {
+        max: 0xFFu8,
+        description: "A dataFormatIdentifier byte: compression method in the high nibble, \
+                      encryption method in the low nibble. 0x00 means neither. Every byte is a \
+                      valid encoding; non-zero values are vehicle-manufacturer specific."
+    },
+    DtcFormatIdentifier {
+        max: 0xFFu8,
+        description: "A DTCFormatIdentifier byte (ISO 14229-1:2020 Table 331). 0x00 to 0x04 are \
+                      defined formats; every other byte classifies as ISOSAEReserved rather than \
+                      being rejected."
+    },
+    DtcSettingType {
+        max: 0x7Eu8,
+        description: "A DTCSettingType byte (ISO 14229-1:2020 Table 128). Only 0x01 (on), 0x02 \
+                      (off), 0x40 to 0x5F (vehicle-manufacturer specific) and 0x60 to 0x7E \
+                      (system-supplier specific) are accepted; 0x00, 0x03 to 0x3F and 0x7F are \
+                      reserved and rejected. The set is not contiguous, so the minimum and \
+                      maximum here are looser than the real constraint."
+    },
+    FileOperationMode {
+        max: 0xFFu8,
+        description: "A RequestFileTransfer modeOfOperation byte (ISO 14229-1:2020 Table 485). \
+                      0x01 to 0x06 are defined; every other byte classifies as ISOSAEReserved \
+                      rather than being rejected."
+    },
+    FunctionalGroupIdentifier {
+        max: 0xFFu8,
+        description: "A functionalGroupIdentifier byte (ISO 14229-1:2020 Annex D). Every byte \
+                      classifies: undefined values become ISOSAEReserved rather than being \
+                      rejected."
+    },
+    SecurityAccessType {
+        max: 0x7Fu8,
+        description: "A SecurityAccess sub-function byte, 0x00 to 0x7F. Odd values request a \
+                      seed and even values send a key. Bit 7 is the \
+                      suppressPosRspMsgIndicationBit and is carried separately, so a value with \
+                      it set is rejected."
+    },
+    SubnetNumber {
+        max: 0x0Fu8,
+        description: "A subnetNumber nibble, 0x00 to 0x0F (ISO 14229-1:2020 Annex B Table B.1). \
+                      0x00 addresses the receiving node including all connected networks, 0x0F \
+                      the network the request arrived on, and 0x01 to 0x0E a specific subnet. It \
+                      occupies the high nibble of the communicationType byte, so anything wider \
+                      than a nibble is rejected."
+    },
 );

--- a/src/shared/byte_schema.rs
+++ b/src/shared/byte_schema.rs
@@ -27,7 +27,6 @@ macro_rules! byte_schema {
 
 byte_schema!(
     CommunicationControlType,
-    CommunicationType,
     DataFormatIdentifier,
     DtcSettingType,
     SecurityAccessType,

--- a/src/shared/byte_schema.rs
+++ b/src/shared/byte_schema.rs
@@ -1,0 +1,35 @@
+//! `OpenAPI` schemas for the types that serialize as a single protocol byte.
+//!
+//! Several public types are one wire byte with a range invariant. Their `serde` impls go
+//! through `u8` (via `serde(try_from = "u8", into = "u8")`) so that deserializing cannot build a
+//! value their constructor would reject. A derived `ToSchema` would still describe the Rust
+//! shape — an object with nibble properties, or a `oneOf` over variant names — and so disagree
+//! with what `serde` actually reads and writes. These impls keep the two in step.
+
+/// Implement `PartialSchema`/`ToSchema` for types whose serialized form is a `u8`.
+macro_rules! byte_schema {
+    ($($ty:ident),* $(,)?) => {
+        $(
+            impl utoipa::PartialSchema for crate::$ty {
+                fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                    <u8 as utoipa::PartialSchema>::schema()
+                }
+            }
+
+            impl utoipa::ToSchema for crate::$ty {
+                fn name() -> std::borrow::Cow<'static, str> {
+                    std::borrow::Cow::Borrowed(stringify!($ty))
+                }
+            }
+        )*
+    };
+}
+
+byte_schema!(
+    CommunicationControlType,
+    CommunicationType,
+    DataFormatIdentifier,
+    DtcSettingType,
+    SecurityAccessType,
+    SubnetNumber,
+);

--- a/src/shared/diagnostic_identifier.rs
+++ b/src/shared/diagnostic_identifier.rs
@@ -5,7 +5,7 @@
 /// The identifiers listed here are defined and should be implemented by the vehicle manufacturer/system supplier.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum, clap::Parser))]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[derive(Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UdsIdentifier {

--- a/src/shared/diagnostic_identifier.rs
+++ b/src/shared/diagnostic_identifier.rs
@@ -35,7 +35,7 @@ pub enum UdsIdentifier {
     PeriodicDataIdentifier(u16),
     /// Dynamically defined data identifier (`0xF300–0xF3FF`).
     #[cfg_attr(feature = "clap", clap(skip))]
-    DynamicallyDefinedDataIdentifier(u16),
+    DynamicallyDefineDataIdentifier(u16),
     /// OBD data identifier (`0xF400–0xF5FF`, `0xF700–0xF7FF`).
     #[cfg_attr(feature = "clap", clap(skip))]
     ObdDataIdentifier(u16),
@@ -190,7 +190,7 @@ impl From<u16> for UdsIdentifier {
             0xF1A0..=0xF1EF => Self::IdentificationOptionVehicleManufacturerSpecific(value),
             0xF1F0..=0xF1FF => Self::IdentificationOptionSystemSupplierSpecific(value),
             0xF200..=0xF2FF => Self::PeriodicDataIdentifier(value),
-            0xF300..=0xF3FF => Self::DynamicallyDefinedDataIdentifier(value),
+            0xF300..=0xF3FF => Self::DynamicallyDefineDataIdentifier(value),
             0xF400..=0xF5FF => Self::ObdDataIdentifier(value),
             0xF600..=0xF6FF => Self::ObdMonitorDataIdentifier(value),
             0xF700..=0xF7FF => Self::ObdDataIdentifier(value),
@@ -223,7 +223,7 @@ impl From<UdsIdentifier> for u16 {
             UdsIdentifier::IdentificationOptionVehicleManufacturerSpecific(v) => v,
             UdsIdentifier::IdentificationOptionSystemSupplierSpecific(v) => v,
             UdsIdentifier::PeriodicDataIdentifier(v) => v,
-            UdsIdentifier::DynamicallyDefinedDataIdentifier(v) => v,
+            UdsIdentifier::DynamicallyDefineDataIdentifier(v) => v,
             UdsIdentifier::ObdDataIdentifier(v) => v,
             UdsIdentifier::ObdMonitorDataIdentifier(v) => v,
             UdsIdentifier::ObdInfoTypeDataIdentifier(v) => v,

--- a/src/shared/format_identifiers.rs
+++ b/src/shared/format_identifiers.rs
@@ -39,8 +39,6 @@ const ENCRYPTION_NIBBLE_MASK: u8 = LOW_NIBBLE_MASK;
 /// either type's public surface.
 ///
 /// See ISO-14229-1:2020, Table H.1 for format information
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct MemoryFormatIdentifier {
     pub memory_size_length: u8,
@@ -84,8 +82,6 @@ impl From<MemoryFormatIdentifier> for u8 {
 /// length of `max_number_of_block_length`, i.e. `0x20` means that field is 2 bytes long.
 /// Derived from the slice length when encoding, so it is not part of either response's
 /// public surface.
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct LengthFormatIdentifier {
     pub max_number_of_block_length: u8,

--- a/src/shared/format_identifiers.rs
+++ b/src/shared/format_identifiers.rs
@@ -177,6 +177,14 @@ impl DataFormatIdentifier {
         self.compression_method
     }
 
+    /// The single byte this identifier occupies on the wire.
+    ///
+    /// `const`, unlike `u8::from(identifier)`, so it can be used in a `const` context.
+    #[must_use]
+    pub const fn value(&self) -> u8 {
+        self.encryption_method | (self.compression_method << 4)
+    }
+
     /// The encryption method nibble (the low nibble on the wire).
     ///
     /// `0x00` means no encryption. Other values are vehicle-manufacturer specific.

--- a/src/shared/format_identifiers.rs
+++ b/src/shared/format_identifiers.rs
@@ -56,10 +56,10 @@ impl TryFrom<u8> for MemoryFormatIdentifier {
         let memory_address_length = value & MEMORY_ADDRESS_NIBBLE_MASK;
 
         if !matches!(memory_size_length, 1..=MAX_MEMORY_SIZE_LENGTH) {
-            return Err(Error::IncorrectMessageLengthOrInvalidFormat);
+            return Err(Error::InvalidAddressAndLengthFormatIdentifier(value));
         }
         if !matches!(memory_address_length, 1..=MAX_MEMORY_ADDRESS_LENGTH) {
-            return Err(Error::IncorrectMessageLengthOrInvalidFormat);
+            return Err(Error::InvalidAddressAndLengthFormatIdentifier(value));
         }
         Ok(Self {
             memory_size_length,
@@ -82,28 +82,26 @@ impl From<MemoryFormatIdentifier> for u8 {
 /// length of `max_number_of_block_length`, i.e. `0x20` means that field is 2 bytes long.
 /// Derived from the slice length when encoding, so it is not part of either response's
 /// public surface.
+///
+/// The low nibble is not retained. ISO 14229-1:2020 Tables 443 and 448 both state that bits
+/// 3 to 0 are "reserved by document, to be set to '0'", and that "the lower nibble **shall**
+/// be set to '0'" — the byte range they give is `0x00` to `0xF0`. A non-zero low nibble is
+/// therefore not a value to echo back but a malformed byte, so encoding always emits zero.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct LengthFormatIdentifier {
     pub max_number_of_block_length: u8,
-    /// The low nibble, which ISO 14229-1 does not define for this byte.
-    ///
-    /// Retained rather than zeroed so a decode/re-encode is byte-exact: a server that sets it
-    /// gets its own byte back. Encoding a freshly constructed response leaves it `0`.
-    pub reserved_low_nibble: u8,
 }
 
 impl From<u8> for LengthFormatIdentifier {
     fn from(value: u8) -> Self {
         Self {
             max_number_of_block_length: (value & BLOCK_LENGTH_NIBBLE_MASK) >> 4,
-            reserved_low_nibble: value & LOW_NIBBLE_MASK,
         }
     }
 }
 impl From<LengthFormatIdentifier> for u8 {
     fn from(length_format_identifier: LengthFormatIdentifier) -> u8 {
-        (length_format_identifier.max_number_of_block_length << 4)
-            | length_format_identifier.reserved_low_nibble
+        length_format_identifier.max_number_of_block_length << 4
     }
 }
 
@@ -232,11 +230,17 @@ mod tests {
 
     #[test]
     fn failed_memory_format_identifier() {
+        // Tables 444 and 449 both put an invalid addressAndLengthFormatIdentifier on NRC 0x31
+        // requestOutOfRange, not 0x13.
         let memory_format_identifier = MemoryFormatIdentifier::try_from(0x00);
         assert!(matches!(
             memory_format_identifier,
-            Err(Error::IncorrectMessageLengthOrInvalidFormat)
+            Err(Error::InvalidAddressAndLengthFormatIdentifier(0x00))
         ));
+        assert_eq!(
+            Error::InvalidAddressAndLengthFormatIdentifier(0x00).negative_response_code(),
+            Some(crate::NegativeResponseCode::RequestOutOfRange)
+        );
     }
 
     #[test]
@@ -320,13 +324,14 @@ mod tests {
             }
 
             #[test]
-            fn prop_length_format_identifier_roundtrip(byte in any::<u8>()) {
-                // Every byte round-trips, including one with the ISO-undefined low nibble set.
-                // This generator used to be `high_nibble << 4`, so the low nibble was always
-                // zero and the property held trivially while the impl silently zeroed it.
+            fn prop_length_format_identifier_normalizes_the_reserved_nibble(byte in any::<u8>()) {
+                // Tables 443 and 448 require the low nibble to be '0', so re-encoding any byte
+                // must clear it while preserving the block-length nibble. Generating the full
+                // `u8` range rather than `high_nibble << 4` is what makes this a real property:
+                // the narrower generator held trivially whichever way the impl behaved.
                 let lfi = LengthFormatIdentifier::from(byte);
                 let back: u8 = lfi.into();
-                prop_assert_eq!(byte, back);
+                prop_assert_eq!(byte & 0xF0, back);
             }
 
             #[test]

--- a/src/shared/format_identifiers.rs
+++ b/src/shared/format_identifiers.rs
@@ -85,18 +85,25 @@ impl From<MemoryFormatIdentifier> for u8 {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct LengthFormatIdentifier {
     pub max_number_of_block_length: u8,
+    /// The low nibble, which ISO 14229-1 does not define for this byte.
+    ///
+    /// Retained rather than zeroed so a decode/re-encode is byte-exact: a server that sets it
+    /// gets its own byte back. Encoding a freshly constructed response leaves it `0`.
+    pub reserved_low_nibble: u8,
 }
 
 impl From<u8> for LengthFormatIdentifier {
     fn from(value: u8) -> Self {
         Self {
             max_number_of_block_length: (value & BLOCK_LENGTH_NIBBLE_MASK) >> 4,
+            reserved_low_nibble: value & LOW_NIBBLE_MASK,
         }
     }
 }
 impl From<LengthFormatIdentifier> for u8 {
     fn from(length_format_identifier: LengthFormatIdentifier) -> u8 {
-        length_format_identifier.max_number_of_block_length << 4
+        (length_format_identifier.max_number_of_block_length << 4)
+            | length_format_identifier.reserved_low_nibble
     }
 }
 
@@ -305,9 +312,10 @@ mod tests {
             }
 
             #[test]
-            fn prop_length_format_identifier_roundtrip(high_nibble in 0u8..=15) {
-                // LengthFormatIdentifier only stores the high nibble
-                let byte = high_nibble << 4;
+            fn prop_length_format_identifier_roundtrip(byte in any::<u8>()) {
+                // Every byte round-trips, including one with the ISO-undefined low nibble set.
+                // This generator used to be `high_nibble << 4`, so the low nibble was always
+                // zero and the property held trivially while the impl silently zeroed it.
                 let lfi = LengthFormatIdentifier::from(byte);
                 let back: u8 = lfi.into();
                 prop_assert_eq!(byte, back);

--- a/src/shared/format_identifiers.rs
+++ b/src/shared/format_identifiers.rs
@@ -29,23 +29,99 @@ const BLOCK_LENGTH_NIBBLE_MASK: u8 = HIGH_NIBBLE_MASK;
 const COMPRESSION_NIBBLE_MASK: u8 = HIGH_NIBBLE_MASK;
 const ENCRYPTION_NIBBLE_MASK: u8 = LOW_NIBBLE_MASK;
 
-/// Takes in the actual memory address to be used and the size of the memory to be used
-/// and computes how many bytes are needed to represent them
+/// How many bytes the `memoryAddress` and `memorySize` parameters occupy on the wire.
 ///
-/// Carried by the `addressAndLengthFormatIdentifier` byte of
+/// The `addressAndLengthFormatIdentifier` byte of
 /// [`RequestDownloadRequest`](crate::RequestDownloadRequest) and
 /// [`RequestUploadRequest`](crate::RequestUploadRequest), which share one message layout.
-/// Derived from the address and size rather than set by the caller, so it is not part of
-/// either type's public surface.
+/// The high nibble is the `memorySize` width and the low nibble the `memoryAddress` width, in
+/// bytes — so `0x44` declares four bytes each, and `0x12` one byte of size and two of address.
 ///
-/// See ISO-14229-1:2020, Table H.1 for format information
+/// ISO 14229-1:2020 Table 441 makes this a client choice rather than a function of the values, so
+/// it is a parameter rather than something derived: clause 11.3.1 blesses "a **fixed**
+/// addressAndLengthFormatIdentifier" with the unused bytes "padded with the value 0x00", and the
+/// standard's own examples are non-minimal (Table 462 declares three `memorySize` bytes for
+/// `0x00FFFF`, which needs two). Pass one to
+/// [`RequestDownloadRequest::new_with_alfid`](crate::RequestDownloadRequest::new_with_alfid);
+/// [`new`](crate::RequestDownloadRequest::new) derives the minimal one for you.
+///
+/// A bootloader that mandates a particular value states it as a byte, so build one the same way:
+///
+/// ```
+/// use uds_protocol::AddressAndLengthFormatIdentifier as Alfid;
+///
+/// let alfid = Alfid::try_from(0x44).expect("four bytes each is within Table H.1");
+/// assert_eq!(alfid.memory_size_length(), 4);
+/// assert_eq!(alfid.memory_address_length(), 4);
+/// assert_eq!(u8::from(alfid), 0x44);
+///
+/// // Annex H Table H.1 marks a zero nibble, and any size above 4, "not applicable".
+/// assert!(Alfid::try_from(0x40).is_err());
+/// assert!(Alfid::try_from(0x54).is_err());
+/// ```
+///
+/// See ISO 14229-1:2020 Annex H Table H.1 for the applicable widths.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct MemoryFormatIdentifier {
-    pub memory_size_length: u8,
-    pub memory_address_length: u8,
+pub struct AddressAndLengthFormatIdentifier {
+    /// Width of `memorySize` in bytes: 1 to 4. Private so it cannot leave Table H.1's range.
+    memory_size_length: u8,
+    /// Width of `memoryAddress` in bytes: 1 to 5. Private for the same reason.
+    memory_address_length: u8,
 }
 
-impl TryFrom<u8> for MemoryFormatIdentifier {
+impl AddressAndLengthFormatIdentifier {
+    /// Build one from its two widths, in bytes.
+    ///
+    /// Arguments are in **wire order**: `memory_size_length` is the high nibble,
+    /// `memory_address_length` the low nibble. Both are `u8`, so the compiler cannot catch a
+    /// transposition — if you have the byte already, prefer `try_from`, which cannot be
+    /// transposed.
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidAddressAndLengthFormatIdentifier`] carrying the byte the widths
+    /// would have formed if `memory_size_length` is outside 1 to 4 or `memory_address_length` is
+    /// outside 1 to 5, which Annex H Table H.1 marks "not applicable".
+    pub const fn new(memory_size_length: u8, memory_address_length: u8) -> Result<Self, Error> {
+        if !matches!(memory_size_length, 1..=MAX_MEMORY_SIZE_LENGTH)
+            || !matches!(memory_address_length, 1..=MAX_MEMORY_ADDRESS_LENGTH)
+        {
+            // Report the byte, not the nibble, so the message matches what a tester configures
+            // and what `try_from` would have been given. Nibbles wider than 4 bits are masked to
+            // keep the reported byte a faithful packing of the two.
+            return Err(Error::InvalidAddressAndLengthFormatIdentifier(
+                ((memory_size_length & LOW_NIBBLE_MASK) << 4)
+                    | (memory_address_length & LOW_NIBBLE_MASK),
+            ));
+        }
+        Ok(Self {
+            memory_size_length,
+            memory_address_length,
+        })
+    }
+
+    /// Width of the `memorySize` parameter in bytes, 1 to 4. The high nibble.
+    #[must_use]
+    pub const fn memory_size_length(self) -> u8 {
+        self.memory_size_length
+    }
+
+    /// Width of the `memoryAddress` parameter in bytes, 1 to 5. The low nibble.
+    #[must_use]
+    pub const fn memory_address_length(self) -> u8 {
+        self.memory_address_length
+    }
+}
+
+impl PartialEq<u8> for AddressAndLengthFormatIdentifier {
+    /// Wire equality: compares the packed byte, so `alfid == 0x44` reads as it does in the spec.
+    fn eq(&self, other: &u8) -> bool {
+        (self.memory_size_length << 4) | self.memory_address_length == *other
+    }
+}
+
+impl TryFrom<u8> for AddressAndLengthFormatIdentifier {
     type Error = Error;
     fn try_from(value: u8) -> Result<Self, Error> {
         // High nibble: bytes used for the memorySize parameter. Table H.1 marks 1 through 4
@@ -68,17 +144,16 @@ impl TryFrom<u8> for MemoryFormatIdentifier {
     }
 }
 
-impl From<MemoryFormatIdentifier> for u8 {
-    fn from(memory_format_identifier: MemoryFormatIdentifier) -> u8 {
-        (memory_format_identifier.memory_size_length << 4)
-            | memory_format_identifier.memory_address_length
+impl From<AddressAndLengthFormatIdentifier> for u8 {
+    fn from(alfid: AddressAndLengthFormatIdentifier) -> u8 {
+        (alfid.memory_size_length << 4) | alfid.memory_address_length
     }
 }
 
 /// The leading byte of a [`RequestDownloadResponse`](crate::RequestDownloadResponse) or
 /// [`RequestUploadResponse`](crate::RequestUploadResponse), which share one message layout.
 ///
-/// The format mirrors [`MemoryFormatIdentifier`]: a byte whose high nibble gives the byte
+/// The format mirrors [`AddressAndLengthFormatIdentifier`]: a byte whose high nibble gives the byte
 /// length of `max_number_of_block_length`, i.e. `0x20` means that field is 2 bytes long.
 /// Derived from the slice length when encoding, so it is not part of either response's
 /// public surface.
@@ -221,7 +296,7 @@ mod tests {
     use super::*;
     #[test]
     fn memory_format_identifier() {
-        let memory_format_identifier = MemoryFormatIdentifier::try_from(0x23).unwrap();
+        let memory_format_identifier = AddressAndLengthFormatIdentifier::try_from(0x23).unwrap();
         assert_eq!(memory_format_identifier.memory_size_length, 2);
         assert_eq!(memory_format_identifier.memory_address_length, 3);
 
@@ -232,7 +307,7 @@ mod tests {
     fn failed_memory_format_identifier() {
         // Tables 444 and 449 both put an invalid addressAndLengthFormatIdentifier on NRC 0x31
         // requestOutOfRange, not 0x13.
-        let memory_format_identifier = MemoryFormatIdentifier::try_from(0x00);
+        let memory_format_identifier = AddressAndLengthFormatIdentifier::try_from(0x00);
         assert!(matches!(
             memory_format_identifier,
             Err(Error::InvalidAddressAndLengthFormatIdentifier(0x00))
@@ -251,7 +326,7 @@ mod tests {
         for size_len in 1..=4u8 {
             for addr_len in 1..=5u8 {
                 let byte = (size_len << 4) | addr_len;
-                let mfi = MemoryFormatIdentifier::try_from(byte)
+                let mfi = AddressAndLengthFormatIdentifier::try_from(byte)
                     .unwrap_or_else(|e| panic!("Table H.1 lists {byte:#04X} as valid, got {e:?}"));
                 assert_eq!(mfi.memory_size_length, size_len, "for {byte:#04X}");
                 assert_eq!(mfi.memory_address_length, addr_len, "for {byte:#04X}");
@@ -266,7 +341,7 @@ mod tests {
         // and 5 (address).
         for byte in [0x00, 0x01, 0x10, 0x05, 0x50, 0x46, 0x55, 0xF5, 0x5F] {
             assert!(
-                MemoryFormatIdentifier::try_from(byte).is_err(),
+                AddressAndLengthFormatIdentifier::try_from(byte).is_err(),
                 "{byte:#04X} is not applicable per Table H.1 but was accepted"
             );
         }
@@ -343,7 +418,7 @@ mod tests {
                 addr_len in 1u8..=MAX_MEMORY_ADDRESS_LENGTH,
             ) {
                 let byte = (size_len << 4) | addr_len;
-                let mfi = MemoryFormatIdentifier::try_from(byte).unwrap();
+                let mfi = AddressAndLengthFormatIdentifier::try_from(byte).unwrap();
                 let back: u8 = mfi.into();
                 prop_assert_eq!(byte, back);
             }

--- a/src/shared/format_identifiers.rs
+++ b/src/shared/format_identifiers.rs
@@ -116,8 +116,11 @@ impl From<LengthFormatIdentifier> for u8 {
 /// [`RequestDownloadRequest::data_format_identifier`](crate::RequestDownloadRequest::data_format_identifier).
 /// Also carried by the `AddFile`, `ReplaceFile`, `ReadFile` and `ResumeFile` variants of
 /// [`RequestFileTransferRequest`](crate::RequestFileTransferRequest).
+/// Serializes as the single wire byte it occupies. Going through the byte rather than the two
+/// private nibble fields means `serde` cannot mint a nibble wider than `0x0F`, which `new`
+/// rejects — the byte form simply has no such state to represent.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "serde", serde(from = "u8", into = "u8"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DataFormatIdentifier {
     // low nibble

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "utoipa")]
+mod byte_schema;
+
 mod diagnostic_identifier;
 pub use diagnostic_identifier::{UdsIdentifier, UdsRoutineIdentifier};
 

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -13,8 +13,5 @@ pub(crate) use suppressable_positive_response::{
 };
 
 mod format_identifiers;
-pub use format_identifiers::DataFormatIdentifier;
-pub(crate) use format_identifiers::{
-    LengthFormatIdentifier, MAX_MEMORY_ADDRESS_LENGTH, MAX_MEMORY_SIZE_LENGTH,
-    MemoryFormatIdentifier,
-};
+pub(crate) use format_identifiers::LengthFormatIdentifier;
+pub use format_identifiers::{AddressAndLengthFormatIdentifier, DataFormatIdentifier};

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -11,4 +11,7 @@ pub(crate) use suppressable_positive_response::{
 
 mod format_identifiers;
 pub use format_identifiers::DataFormatIdentifier;
-pub(crate) use format_identifiers::{LengthFormatIdentifier, MemoryFormatIdentifier};
+pub(crate) use format_identifiers::{
+    LengthFormatIdentifier, MAX_MEMORY_ADDRESS_LENGTH, MAX_MEMORY_SIZE_LENGTH,
+    MemoryFormatIdentifier,
+};

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -9,7 +9,7 @@ pub use negative_response_code::NegativeResponseCode;
 
 mod suppressable_positive_response;
 pub(crate) use suppressable_positive_response::{
-    SuppressablePositiveResponse, fuse_sprmib, split_sprmib,
+    SPRMIB_VALUE_MASK, SuppressablePositiveResponse, fuse_sprmib, split_sprmib,
 };
 
 mod format_identifiers;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -12,6 +12,9 @@ pub(crate) use suppressable_positive_response::{
     SPRMIB_VALUE_MASK, SuppressablePositiveResponse, fuse_sprmib, split_sprmib,
 };
 
+#[cfg(feature = "serde")]
+pub(crate) mod bounded;
+
 mod format_identifiers;
 pub(crate) use format_identifiers::LengthFormatIdentifier;
 pub use format_identifiers::{AddressAndLengthFormatIdentifier, DataFormatIdentifier};

--- a/src/shared/negative_response_code.rs
+++ b/src/shared/negative_response_code.rs
@@ -160,54 +160,65 @@ pub enum NegativeResponseCode {
     ReservedForSpecificConditionsNotMet(u8),
 }
 
-impl From<NegativeResponseCode> for u8 {
+impl NegativeResponseCode {
+    /// The raw NRC byte.
+    ///
+    /// `const`, unlike `u8::from(nrc)`, so a server dispatch table built in a `const`
+    /// context can read the code back out.
+    #[must_use]
     #[allow(clippy::match_same_arms)]
-    fn from(value: NegativeResponseCode) -> Self {
-        match value {
-            NegativeResponseCode::PositiveResponse => 0x00,
-            NegativeResponseCode::IsoSaeReserved(value) => value,
-            NegativeResponseCode::GeneralReject => 0x10,
-            NegativeResponseCode::ServiceNotSupported => 0x11,
-            NegativeResponseCode::SubFunctionNotSupported => 0x12,
-            NegativeResponseCode::IncorrectMessageLengthOrInvalidFormat => 0x13,
-            NegativeResponseCode::ResponseTooLong => 0x14,
-            NegativeResponseCode::BusyRepeatRequest => 0x21,
-            NegativeResponseCode::ConditionsNotCorrect => 0x22,
-            NegativeResponseCode::RequestSequenceError => 0x24,
-            NegativeResponseCode::RequestOutOfRange => 0x31,
-            NegativeResponseCode::SecurityAccessDenied => 0x33,
-            NegativeResponseCode::AuthenticationRequired => 0x34,
-            NegativeResponseCode::InvalidKey => 0x35,
-            NegativeResponseCode::ExceedNumberOfAttempts => 0x36,
-            NegativeResponseCode::RequiredTimeDelayNotExpired => 0x37,
-            NegativeResponseCode::ExtendedDataLinkSecurityReserved(value) => value,
-            NegativeResponseCode::UploadDownloadNotAccepted => 0x70,
-            NegativeResponseCode::TransferDataSuspended => 0x71,
-            NegativeResponseCode::GeneralProgrammingFailure => 0x72,
-            NegativeResponseCode::WrongBlockSequenceCounter => 0x73,
-            NegativeResponseCode::RequestCorrectlyReceivedResponsePending => 0x78,
-            NegativeResponseCode::SubFunctionNotSupportedInActiveSession => 0x7E,
-            NegativeResponseCode::ServiceNotSupportedInActiveSession => 0x7F,
-            NegativeResponseCode::RpmTooHigh => 0x81,
-            NegativeResponseCode::RpmTooLow => 0x82,
-            NegativeResponseCode::EngineIsRunning => 0x83,
-            NegativeResponseCode::EngineIsNotRunning => 0x84,
-            NegativeResponseCode::EngineRunTimeTooLow => 0x85,
-            NegativeResponseCode::TemperatureTooHigh => 0x86,
-            NegativeResponseCode::TemperatureTooLow => 0x87,
-            NegativeResponseCode::VehicleSpeedTooHigh => 0x88,
-            NegativeResponseCode::VehicleSpeedTooLow => 0x89,
-            NegativeResponseCode::ThrottleOrPedalTooHigh => 0x8A,
-            NegativeResponseCode::ThrottleOrPedalTooLow => 0x8B,
-            NegativeResponseCode::TransmissionRangeNotInNeutral => 0x8C,
-            NegativeResponseCode::TransmissionRangeNotInGear => 0x8D,
-            NegativeResponseCode::BrakeSwitchNotClosed => 0x8F,
-            NegativeResponseCode::ShifterLeverNotInPark => 0x90,
-            NegativeResponseCode::TorqueConverterClutchLocked => 0x91,
-            NegativeResponseCode::VoltageTooHigh => 0x92,
-            NegativeResponseCode::VoltageTooLow => 0x93,
-            NegativeResponseCode::ReservedForSpecificConditionsNotMet(value) => value,
+    pub const fn value(&self) -> u8 {
+        match self {
+            Self::PositiveResponse => 0x00,
+            Self::IsoSaeReserved(value) => *value,
+            Self::GeneralReject => 0x10,
+            Self::ServiceNotSupported => 0x11,
+            Self::SubFunctionNotSupported => 0x12,
+            Self::IncorrectMessageLengthOrInvalidFormat => 0x13,
+            Self::ResponseTooLong => 0x14,
+            Self::BusyRepeatRequest => 0x21,
+            Self::ConditionsNotCorrect => 0x22,
+            Self::RequestSequenceError => 0x24,
+            Self::RequestOutOfRange => 0x31,
+            Self::SecurityAccessDenied => 0x33,
+            Self::AuthenticationRequired => 0x34,
+            Self::InvalidKey => 0x35,
+            Self::ExceedNumberOfAttempts => 0x36,
+            Self::RequiredTimeDelayNotExpired => 0x37,
+            Self::ExtendedDataLinkSecurityReserved(value) => *value,
+            Self::UploadDownloadNotAccepted => 0x70,
+            Self::TransferDataSuspended => 0x71,
+            Self::GeneralProgrammingFailure => 0x72,
+            Self::WrongBlockSequenceCounter => 0x73,
+            Self::RequestCorrectlyReceivedResponsePending => 0x78,
+            Self::SubFunctionNotSupportedInActiveSession => 0x7E,
+            Self::ServiceNotSupportedInActiveSession => 0x7F,
+            Self::RpmTooHigh => 0x81,
+            Self::RpmTooLow => 0x82,
+            Self::EngineIsRunning => 0x83,
+            Self::EngineIsNotRunning => 0x84,
+            Self::EngineRunTimeTooLow => 0x85,
+            Self::TemperatureTooHigh => 0x86,
+            Self::TemperatureTooLow => 0x87,
+            Self::VehicleSpeedTooHigh => 0x88,
+            Self::VehicleSpeedTooLow => 0x89,
+            Self::ThrottleOrPedalTooHigh => 0x8A,
+            Self::ThrottleOrPedalTooLow => 0x8B,
+            Self::TransmissionRangeNotInNeutral => 0x8C,
+            Self::TransmissionRangeNotInGear => 0x8D,
+            Self::BrakeSwitchNotClosed => 0x8F,
+            Self::ShifterLeverNotInPark => 0x90,
+            Self::TorqueConverterClutchLocked => 0x91,
+            Self::VoltageTooHigh => 0x92,
+            Self::VoltageTooLow => 0x93,
+            Self::ReservedForSpecificConditionsNotMet(value) => *value,
         }
+    }
+}
+
+impl From<NegativeResponseCode> for u8 {
+    fn from(value: NegativeResponseCode) -> Self {
+        value.value()
     }
 }
 

--- a/src/shared/negative_response_code.rs
+++ b/src/shared/negative_response_code.rs
@@ -74,7 +74,18 @@ pub enum NegativeResponseCode {
     /// This response code indicates that the server detected an error in the sequence of `BlockSequenceCounter` values.
     /// Note that the repetition of a `TransferDataRequest` message with a `BlockSequenceCounter` equal to the one included in the previous `TransferDataRequest` message shall be accepted by the server.
     WrongBlockSequenceCounter,
-    /// This response code indicates that the server detected an error in the sequence of `BlockSequenceCounter` values.
+    /// The request was received correctly and all its parameters were valid, but the server has
+    /// not finished the requested action and is not yet ready to accept another request.
+    ///
+    /// The server sends a final positive or negative response once the service completes, and
+    /// may repeat this code until then. It affects the application-layer timing parameters
+    /// (it extends P2\*), and per ISO 14229-1:2020 Annex A.1 the server "shall always send a
+    /// final response (positive or negative) independent of the
+    /// `suppressPosRspMsgIndicationBit` value" once it has used this code.
+    ///
+    /// Typically used while writing or erasing flash, when the programming routine cannot
+    /// service the bus. Generally supported by every service, which is why it is not listed in
+    /// the individual services' `allowed_nack_codes`.
     RequestCorrectlyReceivedResponsePending,
     /// This response code indicates that the requested action will not be taken because the server does not support the requested sub-function in the session currently active.
     /// Within the programmingSession negative response code 0x12 (subFunctionNotSupported) may optionally be reported instead of negative response code 0x7F (subFunctionNotSupportedInActiveSession).

--- a/src/shared/suppressable_positive_response.rs
+++ b/src/shared/suppressable_positive_response.rs
@@ -28,10 +28,7 @@ pub(crate) const fn fuse_sprmib(suppress_positive_response: bool, value: u8) -> 
 
 /// `SuppressablePositiveResponse` is used to encapsulate subfunction enumerations that can also encode the response suppression bit.
 /// This eliminates bit masking logic from a number of subfunction enumerations.
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub(crate) struct SuppressablePositiveResponse<T: TryFrom<u8> + Into<u8> + Copy> {
     suppress_positive_response: bool,
     value: T,

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -5,9 +5,16 @@ use crate::Encode;
 /// Assert that an [`Encode`] value writes exactly `encoded_size()` bytes — both the
 /// returned count AND the number of bytes actually consumed from the writer.
 ///
-/// Guards against `encode` and `encoded_size` drifting, and against `encode` returning
-/// a count that disagrees with how many bytes it actually wrote — either corrupts callers
-/// that pre-size a buffer from `encoded_size()`.
+/// **This says nothing about *which* bytes get written.** `encoded_size` is a provided method on
+/// [`Encode`] that counts by encoding into a sink, and no type in this crate overrides it, so
+/// every quantity compared here is derived from `encode` itself; the upstream `debug_assert!`
+/// inside `encoded_size` already catches a count that disagrees with the bytes written. What is
+/// left is a real but narrow guarantee: that `encode` is deterministic across two invocations,
+/// that its count matches a write into a real slice, and that the value fits the helper's buffer.
+///
+/// A call to this is therefore **not** byte-correctness coverage. Assert the expected bytes at
+/// the call site as well — the absence of that is what let a swapped pair of encoded fields, and
+/// a transposed pair of format-identifier nibbles, pass the whole suite.
 pub(crate) fn assert_encode_size_agrees<T: Encode>(value: &T)
 where
     T::Error: core::fmt::Debug,

--- a/tests/openapi_schema.rs
+++ b/tests/openapi_schema.rs
@@ -188,6 +188,29 @@ fn no_schema_description_leaks_a_private_type_or_is_empty() {
         .expect("components.schemas");
 
     for (name, schema) in schemas {
+        // Field descriptions are published too, and they come from field rustdoc, so they are
+        // just as capable of naming a private type as the top-level one is.
+        if let Some(properties) = schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+        {
+            for (field, property) in properties {
+                let Some(field_description) = property
+                    .get("description")
+                    .and_then(serde_json::Value::as_str)
+                else {
+                    continue;
+                };
+                for private in PRIVATE {
+                    assert!(
+                        !field_description.contains(private),
+                        "{name}.{field}'s published description names the private type \
+                         `{private}`: {field_description:?}"
+                    );
+                }
+            }
+        }
+
         let description = schema
             .get("description")
             .and_then(serde_json::Value::as_str)

--- a/tests/openapi_schema.rs
+++ b/tests/openapi_schema.rs
@@ -1,0 +1,216 @@
+//! Checks the generated `OpenAPI` document against what `serde` actually does.
+//!
+//! The `utoipa` half of this crate is hand-written for every type whose serialized form is a
+//! single protocol byte, and for the four composite requests that deserialize through a repr. Three
+//! defects shipped in that code because nothing here asserted anything about it:
+//!
+//! - the document had four dangling `$ref`s, where the derive it replaced had none, because a
+//!   hand-written `ToSchema` must forward `schemas()` and none of them did;
+//! - two schema descriptions were implementation notes rather than API documentation, one of them
+//!   naming a module-private type, and one had lost its verb because utoipa's derive silently
+//!   drops `#[doc = concat!(..)]`;
+//! - every byte schema advertised `0..=2^31` while its deserializer rejected anything above
+//!   `0x7F`, or `0x0F`, so a generated client would emit an `i32` and get a runtime rejection.
+//!
+//! A schema that lies is worse than a verbose one, so these are checked, not eyeballed.
+
+#![cfg(all(feature = "utoipa", feature = "serde"))]
+// utoipa's `OpenApi` derive expands to `iter().for_each(..)`, so this lint fires on generated
+// code that this file cannot change.
+#![allow(clippy::needless_for_each)]
+
+use std::collections::BTreeSet;
+
+use utoipa::{OpenApi, PartialSchema};
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(
+    // The four composites with hand-written schemas that delegate to a repr.
+    uds_protocol::CommunicationControlRequest,
+    uds_protocol::TesterPresentRequest,
+    uds_protocol::TesterPresentResponse,
+    uds_protocol::RequestDownloadRequest,
+    uds_protocol::RequestUploadRequest,
+)))]
+struct Api;
+
+fn walk(value: &serde_json::Value, found: &mut BTreeSet<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map {
+                if key == "$ref" {
+                    if let Some(name) = val
+                        .as_str()
+                        .and_then(|s| s.strip_prefix("#/components/schemas/"))
+                    {
+                        found.insert(name.to_owned());
+                    }
+                }
+                walk(val, found);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                walk(item, found);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Every `$ref` in `doc` that points at `#/components/schemas/...`.
+fn referenced_schemas(doc: &serde_json::Value) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    walk(doc, &mut found);
+    found
+}
+
+#[test]
+fn the_document_has_no_dangling_refs() {
+    let json = Api::openapi().to_json().expect("serializes");
+    let doc: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+    let schemas = doc["components"]["schemas"]
+        .as_object()
+        .expect("components.schemas");
+
+    let referenced = referenced_schemas(&doc);
+    let dangling: Vec<&String> = referenced
+        .iter()
+        .filter(|name| !schemas.contains_key(name.as_str()))
+        .collect();
+
+    assert!(
+        dangling.is_empty(),
+        "these schemas are referenced but never defined, so the document does not resolve: \
+         {dangling:?}. A hand-written `ToSchema` must forward `schemas()` — it defaults to a \
+         no-op, and only the derive overrides it."
+    );
+
+    // And the children really are pulled in, so the assertion above is not passing vacuously on
+    // a document that happens to contain no `$ref`s at all.
+    assert!(
+        schemas.contains_key("SubnetNumber"),
+        "expected the composite request to register its child schemas, got {:?}",
+        schemas.keys().collect::<Vec<_>>()
+    );
+}
+
+/// `maximum` on each byte schema must be the largest byte `serde` actually accepts.
+///
+/// This is the assertion that keeps the two from drifting: it does not hard-code a bound, it
+/// discovers it by deserializing all 256 bytes and compares that to what the schema advertises.
+macro_rules! assert_schema_bound_matches_serde {
+    ($ty:ty, $name:literal) => {{
+        let accepted: Vec<u8> = (0u8..=0xFF)
+            .filter(|b| serde_json::from_str::<$ty>(&b.to_string()).is_ok())
+            .collect();
+        let highest_accepted = *accepted
+            .last()
+            .expect(concat!($name, " accepts no byte at all"));
+
+        let schema = serde_json::to_value(<$ty as PartialSchema>::schema()).expect("serializes");
+        let advertised = schema
+            .get("maximum")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} has no `maximum`, so it advertises the whole i32 range while rejecting \
+                     everything above {:#04X}",
+                    $name, highest_accepted
+                )
+            });
+
+        assert_eq!(
+            advertised,
+            u64::from(highest_accepted),
+            "{}: schema says maximum {}, but serde accepts up to {:#04X}",
+            $name,
+            advertised,
+            highest_accepted
+        );
+        assert_eq!(
+            schema.get("type").and_then(serde_json::Value::as_str),
+            Some("integer"),
+            "{} serializes as a bare byte, so its schema must be an integer",
+            $name
+        );
+
+        // A contiguous `minimum..=maximum` cannot express a set with gaps, so any type with gaps
+        // has to say so in prose or the schema is still lying.
+        let description = schema
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_else(|| panic!("{} has no schema description", $name));
+        let lowest_accepted = accepted[0];
+        let contiguous =
+            accepted.len() == usize::from(highest_accepted) - usize::from(lowest_accepted) + 1;
+        if !contiguous {
+            assert!(
+                description.contains("not contiguous"),
+                "{} accepts a set with gaps ({} of {} bytes in range), so its description must \
+                 say so: {description:?}",
+                $name,
+                accepted.len(),
+                usize::from(highest_accepted) - usize::from(lowest_accepted) + 1
+            );
+        }
+    }};
+}
+
+#[test]
+fn every_byte_schema_advertises_the_range_serde_enforces() {
+    use uds_protocol::{
+        CommunicationControlType, DataFormatIdentifier, DtcFormatIdentifier, DtcSettingType,
+        FileOperationMode, FunctionalGroupIdentifier, SecurityAccessType, SubnetNumber,
+    };
+
+    assert_schema_bound_matches_serde!(CommunicationControlType, "CommunicationControlType");
+    assert_schema_bound_matches_serde!(DataFormatIdentifier, "DataFormatIdentifier");
+    assert_schema_bound_matches_serde!(DtcFormatIdentifier, "DtcFormatIdentifier");
+    assert_schema_bound_matches_serde!(DtcSettingType, "DtcSettingType");
+    assert_schema_bound_matches_serde!(FileOperationMode, "FileOperationMode");
+    assert_schema_bound_matches_serde!(FunctionalGroupIdentifier, "FunctionalGroupIdentifier");
+    assert_schema_bound_matches_serde!(SecurityAccessType, "SecurityAccessType");
+    assert_schema_bound_matches_serde!(SubnetNumber, "SubnetNumber");
+}
+
+#[test]
+fn no_schema_description_leaks_a_private_type_or_is_empty() {
+    // Types a downstream crate cannot name. A schema that mentions one hands a client author a
+    // dead end, and these two are the whole reason the reprs exist — so leaking them into the
+    // published description defeats the point.
+    const PRIVATE: [&str; 2] = ["ZeroSubFunction", "MemoryFormatIdentifier"];
+
+    let json = Api::openapi().to_json().expect("serializes");
+    let doc: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+    let schemas = doc["components"]["schemas"]
+        .as_object()
+        .expect("components.schemas");
+
+    for (name, schema) in schemas {
+        let description = schema
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_else(|| panic!("{name} has no schema description"));
+
+        assert!(
+            !description.trim().is_empty(),
+            "{name} has an empty schema description"
+        );
+        for private in PRIVATE {
+            assert!(
+                !description.contains(private),
+                "{name}'s published description names the private type `{private}`: \
+                 {description:?}"
+            );
+        }
+        // The verb-less description this test exists to catch began with a bare newline: utoipa
+        // dropped the `#[doc = concat!(..)]` fragment carrying the sentence's subject and left the
+        // blank line that had followed it. A leading blank line is that exact signature.
+        assert!(
+            !description.starts_with(char::is_whitespace),
+            "{name}'s description starts with whitespace, which is what a dropped \
+             `#[doc = concat!(..)]` fragment leaves behind: {description:?}"
+        );
+    }
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -6,8 +6,8 @@
 //! impossible for anyone else to build still looks constructible from there.
 
 use uds_protocol::{
-    DirSizePayload, DtcFaultDetectionCounterRecord, DtcRecord, FileSizePayload, NamePayload,
-    PositionPayload, SentDataPayload, SizePayload,
+    DirSizePayload, DtcFaultDetectionCounterRecord, DtcFormatIdentifier, DtcRecord,
+    FileSizePayload, NamePayload, PositionPayload, SentDataPayload, SizePayload,
 };
 
 #[test]
@@ -32,6 +32,28 @@ fn every_non_exhaustive_payload_type_has_a_reachable_constructor() {
     let _ = DirSizePayload::new(0x20);
     let _ = PositionPayload::new(0x10);
     let _ = DtcFaultDetectionCounterRecord::new(DtcRecord::new(0, 0, 0), 0);
+}
+
+#[test]
+fn a_reserved_variant_cannot_alias_a_named_one() {
+    // `PartialEq` on these enums is variant equality, not wire equality, so being able to name a
+    // reserved variant with a byte that a named variant also encodes creates a trap:
+    // `DtcFormatIdentifier::IsoSaeReserved(0x01) != Iso14229_1DtcFormat` even though both encode
+    // 0x01. `#[non_exhaustive]` on the byte-carrying variants makes that unconstructible from
+    // out here, so a value can only be obtained through the classifier, which never aliases.
+    //
+    // Constructing one is a compile error, checked by `tests/ui` conventions in spirit; what this
+    // test pins is the positive half — the classifier and the byte accessor agree, and equality
+    // matches the wire for every byte.
+    for byte in 0x00..=0xFFu8 {
+        let format = DtcFormatIdentifier::from(byte);
+        assert_eq!(format.value(), byte, "classifier lost the byte {byte:#04X}");
+        assert_eq!(
+            format == DtcFormatIdentifier::Iso14229_1DtcFormat,
+            byte == 0x01,
+            "equality disagreed with the wire for {byte:#04X}"
+        );
+    }
 }
 
 /// A `derive(Deserialize)` ignores field visibility and range checks, so it is a second,

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -162,6 +162,39 @@ fn a_reserved_variant_cannot_alias_a_named_one() {
 /// that deserializing cannot build a value `new`/`try_from` would have rejected.
 #[cfg(feature = "serde")]
 mod serde_cannot_bypass_validation {
+    #[test]
+    fn tester_present_sub_function_stays_inside_the_seven_bit_range() {
+        use uds_protocol::{TesterPresentRequest, TesterPresentResponse};
+
+        // Bit 7 of the sub-function byte is the SPRMIB and is carried in its own field, so the
+        // sub-function itself is a 7-bit value. This used to be enforced by a mirror struct whose
+        // `TryFrom` called the classifier; it is now enforced by the classifier being serde's
+        // entry point for the field. Same guarantee, so the same bytes must be refused.
+        for byte in 0x80..=0xFFu8 {
+            let json = format!(r#"{{"suppress_positive_response":false,"sub_function":{byte}}}"#);
+            assert!(
+                serde_json::from_str::<TesterPresentRequest>(&json).is_err(),
+                "sub_function {byte:#04X} has bit 7 set and must be rejected"
+            );
+            let json = format!(r#"{{"sub_function":{byte}}}"#);
+            assert!(
+                serde_json::from_str::<TesterPresentResponse>(&json).is_err(),
+                "response sub_function {byte:#04X} has bit 7 set and must be rejected"
+            );
+        }
+
+        // And every legal byte round-trips, reserved values included, so the range check did not
+        // become a blanket rejection.
+        for byte in 0x00..=0x7Fu8 {
+            let json = format!(r#"{{"suppress_positive_response":true,"sub_function":{byte}}}"#);
+            let req: TesterPresentRequest =
+                serde_json::from_str(&json).expect("0x00..=0x7F is legal");
+            assert_eq!(req.sub_function(), byte);
+            assert!(req.suppress_positive_response);
+            assert_eq!(serde_json::to_string(&req).unwrap(), json);
+        }
+    }
+
     use uds_protocol::{
         CommunicationType, DataFormatIdentifier, DtcSettingType, SecurityAccessLevel, SubnetNumber,
     };

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -6,8 +6,8 @@
 //! impossible for anyone else to build still looks constructible from there.
 
 use uds_protocol::{
-    DirSizePayload, DtcFaultDetectionCounterRecord, DtcRecord, FileOperationMode, FileSizePayload,
-    NamePayload, PositionPayload, SentDataPayload, SizePayload,
+    DirSizePayload, DtcFaultDetectionCounterRecord, DtcRecord, FileSizePayload, NamePayload,
+    PositionPayload, SentDataPayload, SizePayload,
 };
 
 #[test]
@@ -26,7 +26,7 @@ fn every_non_exhaustive_payload_type_has_a_reachable_constructor() {
     // a constructor and one did not, which made it unbuildable outside the crate. Pin all
     // seven so the next `#[non_exhaustive]` cannot reintroduce the gap silently.
     let _ = SizePayload::new(0xC350, 0x7530);
-    let _ = NamePayload::new(FileOperationMode::AddFile, "/a");
+    let _ = NamePayload::new("/a");
     let _ = SentDataPayload::new(&[0x02, 0x00]);
     let _ = FileSizePayload::new(0xC350, 0x7530);
     let _ = DirSizePayload::new(0x20);

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -47,17 +47,92 @@ fn dtc_fault_detection_counter_record_is_constructible_downstream() {
 }
 
 #[test]
-fn every_non_exhaustive_payload_type_has_a_reachable_constructor() {
-    // One commit added `#[non_exhaustive]` to seven public structs with `pub` fields. Six had
-    // a constructor and one did not, which made it unbuildable outside the crate. Pin all
-    // seven so the next `#[non_exhaustive]` cannot reintroduce the gap silently.
-    let _ = SizePayload::new(0xC350, 0x7530);
-    let _ = NamePayload::new("/a");
-    let _ = SentDataPayload::new(&[0x02, 0x00]);
-    let _ = FileSizePayload::new(0xC350, 0x7530);
-    let _ = DirSizePayload::new(0x20);
-    let _ = PositionPayload::new(0x10);
-    let _ = DtcFaultDetectionCounterRecord::new(DtcRecord::new(0, 0, 0), 0);
+fn the_payload_data_bags_are_buildable_with_a_struct_literal() {
+    // These five carry no invariant: every field is `pub`, and their encoders derive the wire
+    // widths from the values, so no combination fails. The crate's rule is to encapsulate a
+    // request/response struct *iff* it bears an invariant, so these are plain data bags and a
+    // struct literal must work from out here. They were briefly `#[non_exhaustive]` purely for
+    // symmetry with the invariant-bearing types, which cost a downstream the struct literal
+    // (E0639) and bought nothing -- `DtcFaultDetectionCounterRecord` became unbuildable
+    // entirely and took two follow-up commits to repair.
+    let _ = SizePayload {
+        file_size_uncompressed: 0xC350,
+        file_size_compressed: 0x7530,
+    };
+    let _ = FileSizePayload {
+        file_size_uncompressed: 0xC350,
+        file_size_compressed: 0x7530,
+    };
+    let _ = DirSizePayload {
+        dir_info_length: 0x20,
+    };
+    let _ = PositionPayload {
+        file_position: 0x10,
+    };
+    let _ = DtcFaultDetectionCounterRecord {
+        dtc_record: DtcRecord::new(0, 0, 0),
+        dtc_fault_detection_counter: 0x2A,
+    };
+
+    // The convenience constructors stay, and agree with the literals.
+    assert_eq!(
+        SizePayload::new(0xC350, 0x7530),
+        SizePayload {
+            file_size_uncompressed: 0xC350,
+            file_size_compressed: 0x7530,
+        }
+    );
+}
+
+#[test]
+fn the_two_length_bounded_payloads_reject_an_unencodable_value() {
+    // These two are the ones that genuinely bear an invariant, so they keep both
+    // `#[non_exhaustive]` and a fallible constructor: the wire field carrying the length is one
+    // byte for `SentDataPayload` and two for `NamePayload`, and `encode` used to be the first
+    // thing to notice an over-long value. A struct literal here is correctly a compile error.
+    assert!(SentDataPayload::new(&[0u8; 255]).is_ok());
+    assert!(SentDataPayload::new(&[0u8; 256]).is_err());
+
+    let short = NamePayload::new("/a").expect("a two-character name fits");
+    assert_eq!(short.file_path_and_name, "/a");
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serde_cannot_build_a_reserved_variant_that_aliases_a_named_one() {
+    // This is what the variant seals were supposed to prevent and did not: with a plain derived
+    // `Deserialize`, `{"IsoSaeReserved":1}` produced a value whose `value()` is 0x01 -- the same
+    // byte `Iso14229_1DtcFormat` encodes -- yet compared unequal to it. `#[non_exhaustive]` on
+    // the variant blocked the Rust struct literal and did nothing about serde, so it bought
+    // pattern-matching friction and no guarantee. Routing serde through `u8` is what actually
+    // closes it, for every byte, and it lets the variant be named and destructured again.
+    let round: DtcFormatIdentifier = serde_json::from_str("1").expect("a bare byte");
+    assert_eq!(round, DtcFormatIdentifier::Iso14229_1DtcFormat);
+    assert_eq!(serde_json::to_string(&round).unwrap(), "1");
+
+    // The old escape route no longer parses at all.
+    assert!(serde_json::from_str::<DtcFormatIdentifier>(r#"{"IsoSaeReserved":1}"#).is_err());
+
+    // Every byte survives the round trip through the classifier, so no aliasing state exists.
+    for byte in 0x00..=0xFFu8 {
+        let via_serde: DtcFormatIdentifier =
+            serde_json::from_str(&byte.to_string()).expect("every byte classifies");
+        assert_eq!(via_serde, DtcFormatIdentifier::from(byte));
+        assert_eq!(via_serde, byte, "PartialEq<u8> must be wire equality");
+    }
+}
+
+#[test]
+fn a_reserved_variant_is_nameable_and_destructurable_downstream() {
+    // The seal made both `IsoSaeReserved(b)` and `IsoSaeReserved(..)` E0603 out here, so a
+    // downstream could not even read the byte by matching -- only `value()` worked. For an
+    // audience new to Rust that is a compile error whose text says nothing about the way out.
+    let reserved = DtcFormatIdentifier::from(0xAA);
+    match reserved {
+        DtcFormatIdentifier::IsoSaeReserved(byte) => assert_eq!(byte, 0xAA),
+        other => panic!("0xAA should classify as reserved, got {other:?}"),
+    }
+    assert_eq!(DtcFormatIdentifier::IsoSaeReserved(0xAA), reserved);
 }
 
 #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -300,18 +300,26 @@ mod serde_cannot_bypass_validation {
             .is_err()
         );
         // A width outside Table H.1 is rejected too.
+        // The widths arrive as one addressAndLengthFormatIdentifier byte, so a width outside
+        // Table H.1 is rejected by that type before the request is built: 0x90 declares a
+        // 9-byte memorySize and a 0-byte memoryAddress, both "not applicable".
         assert!(
             serde_json::from_str::<RequestDownloadRequest>(
-                r#"{"data_format_identifier":0,"memory_address":16,"memory_address_length":9,"memory_size":16,"memory_size_length":0}"#
+                r#"{"data_format_identifier":0,"address_and_length_format_identifier":144,"memory_address":16,"memory_size":16}"#
             )
             .is_err()
         );
 
         // A wider-than-minimal declaration survives the round trip, so the ALFID a server was
-        // sent is the one it gets back.
-        let json = r#"{"data_format_identifier":17,"memory_address":6299648,"memory_address_length":3,"memory_size":65535,"memory_size_length":3}"#;
+        // sent is the one it gets back. 0x33 is three bytes each, for values needing two.
+        let json = r#"{"data_format_identifier":17,"address_and_length_format_identifier":51,"memory_address":6299648,"memory_size":65535}"#;
         let req: RequestDownloadRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.memory_address(), 0x0060_2000);
+        assert_eq!(
+            req.address_and_length_format_identifier(),
+            0x33,
+            "the declared widths must survive, not be re-derived as minimal"
+        );
         assert_eq!(serde_json::to_string(&req).unwrap(), json);
     }
 
@@ -319,9 +327,9 @@ mod serde_cannot_bypass_validation {
     fn no_crate_private_type_appears_in_the_serialized_form() {
         use uds_protocol::{RequestDownloadRequest, TesterPresentRequest};
 
-        // `ZeroSubFunction` is module-private and `MemoryFormatIdentifier` is `pub(crate)`, yet
-        // both used to be named components of the serialized shape — and of the generated
-        // OpenAPI schema, giving client generators a type downstream Rust cannot reference.
+        // `ZeroSubFunction` is module-private, yet it used to be a named component of the
+        // serialized shape — and of the generated OpenAPI schema, giving client generators a type
+        // downstream Rust cannot reference.
         let tester = serde_json::to_string(&TesterPresentRequest::new(false)).unwrap();
         assert!(
             !tester.contains("zero_sub_function"),
@@ -329,14 +337,21 @@ mod serde_cannot_bypass_validation {
         );
         assert!(tester.contains("sub_function"), "got {tester}");
 
+        // The transfer requests' widths were the other half of this: they were reached through a
+        // `pub(crate)` type, so the repr flattened them into two derived scalars. The type is now
+        // public and serializes as the single ISO-named byte it is on the wire, so the shape
+        // matches Table 441 instead of paraphrasing it.
         let download =
             RequestDownloadRequest::new(DataFormatIdentifier::NONE, 0x1234, 0x10).unwrap();
         let json = serde_json::to_string(&download).unwrap();
-        assert!(
-            !json.contains("address_and_length_format_identifier"),
-            "leaked a private field name: {json}"
+        assert_eq!(
+            json,
+            r#"{"data_format_identifier":0,"address_and_length_format_identifier":18,"memory_address":4660,"memory_size":16}"#
         );
-        assert!(json.contains("memory_address_length"), "got {json}");
+        assert!(
+            !json.contains("memory_address_length") && !json.contains("memory_size_length"),
+            "the widths are the format identifier byte, not separate fields: {json}"
+        );
     }
 
     #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -94,7 +94,7 @@ fn the_two_length_bounded_payloads_reject_an_unencodable_value() {
     assert!(SentDataPayload::new(&[0u8; 256]).is_err());
 
     let short = NamePayload::new("/a").expect("a two-character name fits");
-    assert_eq!(short.file_path_and_name, "/a");
+    assert_eq!(short.file_path_and_name(), "/a");
 }
 
 #[cfg(feature = "serde")]
@@ -162,6 +162,61 @@ fn a_reserved_variant_cannot_alias_a_named_one() {
 /// that deserializing cannot build a value `new`/`try_from` would have rejected.
 #[cfg(feature = "serde")]
 mod serde_cannot_bypass_validation {
+    #[test]
+    fn a_length_bounded_borrowed_str_cannot_be_deserialized_out_of_bounds() {
+        use uds_protocol::NamePayload;
+
+        // Making a constructor fallible does nothing on its own: `derive(Deserialize)` writes the
+        // fields directly, so it is a second constructor that skips the check. `filePathAndName`
+        // is declared by a two-byte length prefix, so a longer name cannot be encoded.
+        let too_long = "a".repeat(usize::from(u16::MAX) + 1);
+        let json = serde_json::to_string(&serde_json::json!({ "file_path_and_name": too_long }))
+            .expect("serializes");
+        assert!(
+            serde_json::from_str::<NamePayload>(&json).is_err(),
+            "a name longer than the two-byte length prefix must be rejected on the way in"
+        );
+
+        // ...and the longest legal name is still accepted, so the guard is a bound and not a
+        // blanket refusal.
+        let longest = "a".repeat(usize::from(u16::MAX));
+        let json = serde_json::to_string(&serde_json::json!({ "file_path_and_name": longest }))
+            .expect("serializes");
+        let payload: NamePayload =
+            serde_json::from_str(&json).expect("u16::MAX bytes is the largest declarable name");
+        assert_eq!(payload.file_path_and_name().len(), usize::from(u16::MAX));
+    }
+
+    #[test]
+    fn a_borrowed_byte_slice_field_is_not_reachable_through_json_at_all() {
+        use uds_protocol::WriteDataByIdentifierRequest;
+
+        // Worth pinning because it is easy to mistake for validation working. `&'de [u8]` needs a
+        // format with a native byte-string type; JSON has none, so serde_json refuses a sequence
+        // before any length check runs -- "invalid type: sequence, expected a borrowed byte
+        // array". Both of these fail, and the empty one fails for that reason rather than because
+        // the data record is empty.
+        //
+        // So the `deserialize_with` guard on these fields is only exercised by a format that can
+        // borrow bytes (CBOR, MessagePack, bincode). It is still the right place for the check --
+        // this crate does not get to choose the caller's format -- but do not read a passing
+        // serde_json test as evidence that it works.
+        assert!(
+            serde_json::from_str::<WriteDataByIdentifierRequest>(
+                r#"{"identifier":61840,"data":[]}"#
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<WriteDataByIdentifierRequest>(
+                r#"{"identifier":61840,"data":[1,2,3]}"#
+            )
+            .is_err(),
+            "if this starts passing, JSON gained a byte type and the empty-record assertion \
+             above needs to become a real length check"
+        );
+    }
+
     #[test]
     fn tester_present_sub_function_stays_inside_the_seven_bit_range() {
         use uds_protocol::{TesterPresentRequest, TesterPresentResponse};

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -11,6 +11,32 @@ use uds_protocol::{
 };
 
 #[test]
+fn a_tester_can_still_request_an_unmodeled_read_dtc_information_sub_function() {
+    // Sealing `IsoSaeReserved` keeps bit 7 (SPRMIB) out of the sub-function value, but it also
+    // made `IsoSaeReserved(byte)` unwritable out here — so a tester could no longer originate a
+    // request for a report type the crate has not implemented. `try_reserved` is the door.
+    use uds_protocol::{Encode, ReadDtcInfoRequest, ReadDtcInfoSubFunction};
+
+    let sub = ReadDtcInfoSubFunction::try_reserved(0x57).expect("0x57 has bit 7 clear");
+    assert_eq!(sub.value(), 0x57);
+
+    let mut buf = [0u8; 4];
+    let req = ReadDtcInfoRequest::new(false, sub);
+    let written = req.encode_to_slice(&mut buf).expect("encodes");
+    assert_eq!(&buf[..written], &[0x57]);
+
+    // ...and with the positive response suppressed, the flag is fused back in as bit 7.
+    let suppressed = ReadDtcInfoRequest::new(true, sub);
+    let written = suppressed.encode_to_slice(&mut buf).expect("encodes");
+    assert_eq!(&buf[..written], &[0xD7]);
+
+    // Bit 7 is SPRMIB, so it must not be smuggled in as part of the sub-function value:
+    // 0x80 would otherwise encode as a suppressed 0x00.
+    assert!(ReadDtcInfoSubFunction::try_reserved(0x80).is_err());
+    assert!(ReadDtcInfoSubFunction::try_reserved(0xD7).is_err());
+}
+
+#[test]
 fn dtc_fault_detection_counter_record_is_constructible_downstream() {
     // This is the `Item` type of a public iterator and is re-exported at the crate root so
     // callers can name it. Without a constructor, `#[non_exhaustive]` made the only way to
@@ -133,19 +159,19 @@ mod serde_cannot_bypass_validation {
         // two bytes, which this crate's own decoder then rejected.
         assert!(
             serde_json::from_str::<CommunicationControlRequest>(
-                r#"{"suppress_positive_response":false,"control_type":5,"communication_type":1,"subnet":0,"node_id":null}"#
+                r#"{"suppress_positive_response":false,"control_type":5,"communication_type":"Normal","subnet":0,"node_id":null}"#
             )
             .is_err()
         );
         assert!(
             serde_json::from_str::<CommunicationControlRequest>(
-                r#"{"suppress_positive_response":false,"control_type":3,"communication_type":1,"subnet":0,"node_id":10}"#
+                r#"{"suppress_positive_response":false,"control_type":3,"communication_type":"Normal","subnet":0,"node_id":10}"#
             )
             .is_err()
         );
 
         let req: CommunicationControlRequest = serde_json::from_str(
-            r#"{"suppress_positive_response":false,"control_type":5,"communication_type":1,"subnet":15,"node_id":10}"#
+            r#"{"suppress_positive_response":false,"control_type":5,"communication_type":"Normal","subnet":15,"node_id":10}"#
         )
         .unwrap();
         assert_eq!(req.node_id(), Some(10));

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -82,6 +82,108 @@ mod serde_cannot_bypass_validation {
     }
 
     #[test]
+    fn tester_present_cannot_be_given_a_sub_function_that_collides_with_sprmib() {
+        use uds_protocol::TesterPresentRequest;
+
+        // The sub-function field is private precisely so a caller cannot mint a value with bit
+        // 7 set, which is SPRMIB. The derived impl exposed the private field by name and
+        // accepted any variant payload.
+        assert!(
+            serde_json::from_str::<TesterPresentRequest>(
+                r#"{"suppress_positive_response":false,"sub_function":128}"#
+            )
+            .is_err()
+        );
+        // A reserved-but-legal byte is still accepted, because decode must round-trip it.
+        let req: TesterPresentRequest =
+            serde_json::from_str(r#"{"suppress_positive_response":false,"sub_function":66}"#)
+                .unwrap();
+        assert_eq!(req.sub_function(), 0x42);
+    }
+
+    #[test]
+    fn communication_control_cannot_be_given_a_contradictory_node_id() {
+        use uds_protocol::CommunicationControlRequest;
+
+        // `node_id` must be present exactly when `control_type` is an enhanced-address
+        // variant. That rule is the entire reason both fields are private, and deserializing
+        // ignored it: an enhanced type with a null node_id produced a request that encoded to
+        // two bytes, which this crate's own decoder then rejected.
+        assert!(
+            serde_json::from_str::<CommunicationControlRequest>(
+                r#"{"suppress_positive_response":false,"control_type":5,"communication_type":1,"subnet":0,"node_id":null}"#
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<CommunicationControlRequest>(
+                r#"{"suppress_positive_response":false,"control_type":3,"communication_type":1,"subnet":0,"node_id":10}"#
+            )
+            .is_err()
+        );
+
+        let req: CommunicationControlRequest = serde_json::from_str(
+            r#"{"suppress_positive_response":false,"control_type":5,"communication_type":1,"subnet":15,"node_id":10}"#
+        )
+        .unwrap();
+        assert_eq!(req.node_id(), Some(10));
+        assert_eq!(req.subnet(), SubnetNumber::ReceivedOn);
+    }
+
+    #[test]
+    fn transfer_requests_cannot_be_given_a_width_that_truncates_the_value() {
+        use uds_protocol::RequestDownloadRequest;
+
+        // The width nibbles are private so they cannot fall out of step with the values. A
+        // deserialized 8-byte address with a 1-byte declared width silently truncated to one
+        // byte on the wire.
+        assert!(
+            serde_json::from_str::<RequestDownloadRequest>(
+                r#"{"data_format_identifier":0,"memory_address":18446744073709551615,"memory_address_length":1,"memory_size":16,"memory_size_length":1}"#
+            )
+            .is_err()
+        );
+        // A width outside Table H.1 is rejected too.
+        assert!(
+            serde_json::from_str::<RequestDownloadRequest>(
+                r#"{"data_format_identifier":0,"memory_address":16,"memory_address_length":9,"memory_size":16,"memory_size_length":0}"#
+            )
+            .is_err()
+        );
+
+        // A wider-than-minimal declaration survives the round trip, so the ALFID a server was
+        // sent is the one it gets back.
+        let json = r#"{"data_format_identifier":17,"memory_address":6299648,"memory_address_length":3,"memory_size":65535,"memory_size_length":3}"#;
+        let req: RequestDownloadRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.memory_address(), 0x0060_2000);
+        assert_eq!(serde_json::to_string(&req).unwrap(), json);
+    }
+
+    #[test]
+    fn no_crate_private_type_appears_in_the_serialized_form() {
+        use uds_protocol::{RequestDownloadRequest, TesterPresentRequest};
+
+        // `ZeroSubFunction` is module-private and `MemoryFormatIdentifier` is `pub(crate)`, yet
+        // both used to be named components of the serialized shape — and of the generated
+        // OpenAPI schema, giving client generators a type downstream Rust cannot reference.
+        let tester = serde_json::to_string(&TesterPresentRequest::new(false)).unwrap();
+        assert!(
+            !tester.contains("zero_sub_function"),
+            "leaked a private field name: {tester}"
+        );
+        assert!(tester.contains("sub_function"), "got {tester}");
+
+        let download =
+            RequestDownloadRequest::new(DataFormatIdentifier::NONE, 0x1234, 0x10).unwrap();
+        let json = serde_json::to_string(&download).unwrap();
+        assert!(
+            !json.contains("address_and_length_format_identifier"),
+            "leaked a private field name: {json}"
+        );
+        assert!(json.contains("memory_address_length"), "got {json}");
+    }
+
+    #[test]
     fn the_serialized_form_is_the_wire_byte() {
         // Round-tripping through serde must agree with the protocol's own representation,
         // otherwise `serde(try_from)` on the way in and a struct shape on the way out would

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -33,3 +33,67 @@ fn every_non_exhaustive_payload_type_has_a_reachable_constructor() {
     let _ = PositionPayload::new(0x10);
     let _ = DtcFaultDetectionCounterRecord::new(DtcRecord::new(0, 0, 0), 0);
 }
+
+/// A `derive(Deserialize)` ignores field visibility and range checks, so it is a second,
+/// unvalidated constructor for every type whose invariant lives in its constructor. These check
+/// that deserializing cannot build a value `new`/`try_from` would have rejected.
+#[cfg(feature = "serde")]
+mod serde_cannot_bypass_validation {
+    use uds_protocol::{
+        CommunicationType, DataFormatIdentifier, DtcSettingType, SecurityAccessLevel, SubnetNumber,
+    };
+
+    #[test]
+    fn security_access_level_rejects_a_value_that_collides_with_sprmib() {
+        // A level must fit in 0x00..=0x7F, because bit 7 of the sub-function byte is SPRMIB.
+        // Deserializing 0xFF produced a level that encoded to a byte which decoded back as a
+        // *different* level with suppression set — silent semantic corruption.
+        assert!(serde_json::from_str::<SecurityAccessLevel>("255").is_err());
+        let level: SecurityAccessLevel = serde_json::from_str("127").unwrap();
+        assert_eq!(level.value(), 0x7F);
+    }
+
+    #[test]
+    fn data_format_identifier_rejects_an_over_wide_nibble() {
+        // `new` returns Err when either method exceeds 0x0F; JSON must not be a way around it.
+        assert!(
+            serde_json::from_str::<DataFormatIdentifier>(
+                r#"{"encryption_method":255,"compression_method":255}"#
+            )
+            .is_err()
+        );
+        let dfi: DataFormatIdentifier = serde_json::from_str("33").unwrap();
+        assert_eq!(dfi.compression_method(), 0x02);
+        assert_eq!(dfi.encryption_method(), 0x01);
+    }
+
+    #[test]
+    fn range_checked_enums_reject_out_of_range_bytes() {
+        // Each of these has a `try_from` that range-checks the byte; the derived impl let a
+        // caller name the reserved variant directly and skip it.
+        assert!(serde_json::from_str::<SubnetNumber>("16").is_err());
+        assert!(serde_json::from_str::<DtcSettingType>("0").is_err());
+        assert!(serde_json::from_str::<CommunicationType>("7").is_err());
+
+        assert_eq!(
+            serde_json::from_str::<SubnetNumber>("15").unwrap(),
+            SubnetNumber::ReceivedOn
+        );
+    }
+
+    #[test]
+    fn the_serialized_form_is_the_wire_byte() {
+        // Round-tripping through serde must agree with the protocol's own representation,
+        // otherwise `serde(try_from)` on the way in and a struct shape on the way out would
+        // disagree with each other.
+        assert_eq!(
+            serde_json::to_string(&SubnetNumber::ReceivedOn).unwrap(),
+            "15"
+        );
+        assert_eq!(serde_json::to_string(&DtcSettingType::Off).unwrap(), "2");
+        assert_eq!(
+            serde_json::to_string(&SecurityAccessLevel::new(0x11).unwrap()).unwrap(),
+            "17"
+        );
+    }
+}

--- a/tests/spec_conformance.rs
+++ b/tests/spec_conformance.rs
@@ -1,12 +1,19 @@
 //! Round-trips the message-flow example byte sequences printed in ISO 14229-1:2020.
 //!
-//! Every frame below is quoted from a numbered example table in the standard, so this suite
-//! answers a question the rest of the tests cannot: does the crate agree with the document,
-//! rather than merely with itself? A layout error that both `encode` and `decode` share is
-//! invisible to a round-trip test written against the crate's own output, and that is exactly
-//! how several real defects survived — a missing mandatory `DTCFormatIdentifier`, a
-//! `MemorySelection` byte read from the wrong sub-functions, a `powerDownTime` written
-//! unconditionally.
+//! Every frame below is quoted from a numbered example table in the standard, which gives these
+//! tests an oracle the rest of the suite does not have: the bytes come from the document rather
+//! than from the crate.
+//!
+//! **What that does and does not buy.** It catches two things a round-trip against the crate's
+//! own output cannot: a legal frame the crate *rejects* (a missing mandatory
+//! `DTCFormatIdentifier`, a `MemorySelection` byte read from the wrong sub-functions), and an
+//! encode/decode pair that disagree with each other (a `powerDownTime` written unconditionally,
+//! so `51 01` re-encoded as `51 01 00`).
+//!
+//! It does **not** verify field *meaning*. If `encode` and `decode` share a misreading
+//! symmetrically — two same-width adjacent fields transposed in both directions, say — the bytes
+//! still round-trip and every test here passes. Only an assertion on the decoded *value* catches
+//! that, which is the unit tests' job. Do not read a green run here as "the layout is right".
 //!
 //! This is an integration test, so it sees the crate as a downstream user does: anything it
 //! needs must be reachable and constructible through the public API.
@@ -100,6 +107,10 @@ const REQUESTS: &[Example] = &[
             0x79, 0x31, 0x2E, 0x79, 0x78, 0x7A, 0x11, 0x02, 0xC3, 0x50, 0x75, 0x30,
         ],
     },
+    Example {
+        cite: "Table 49 - SecurityAccess request example #1 step #2 (sendKey)",
+        bytes: &[0x27, 0x02, 0xC9, 0xA9],
+    },
 ];
 
 const RESPONSES: &[Example] = &[
@@ -185,6 +196,13 @@ fn every_spec_request_example_decodes_and_re_encodes_unchanged() {
     for Example { cite, bytes } in REQUESTS {
         let req = Request::decode_exact(bytes)
             .unwrap_or_else(|e| panic!("{cite}: decode of {bytes:02X?} failed: {e:?}"));
+        // `Request::Other` carries the SID and payload verbatim, so it round-trips perfectly.
+        // Without this, a frame for a service the crate does not model would pass silently and
+        // this suite would report coverage it does not have.
+        assert!(
+            !matches!(req, Request::Other { .. }),
+            "{cite}: decoded to Request::Other, so this service is not actually modeled"
+        );
         let mut buf = [0u8; BUF];
         let written = req
             .encode_to_slice(&mut buf)
@@ -198,6 +216,11 @@ fn every_spec_response_example_decodes_and_re_encodes_unchanged() {
     for Example { cite, bytes } in RESPONSES {
         let resp = Response::decode_exact(bytes)
             .unwrap_or_else(|e| panic!("{cite}: decode of {bytes:02X?} failed: {e:?}"));
+        // Same trap as on the request side: `Response::Other` round-trips any SID unchanged.
+        assert!(
+            !matches!(resp, Response::Other { .. }),
+            "{cite}: decoded to Response::Other, so this service is not actually modeled"
+        );
         let mut buf = [0u8; BUF];
         let written = resp
             .encode_to_slice(&mut buf)
@@ -207,22 +230,38 @@ fn every_spec_response_example_decodes_and_re_encodes_unchanged() {
 }
 
 #[test]
-fn the_spec_examples_cover_every_service_the_crate_models() {
-    // Guards against a service quietly dropping out of this suite. Update the expected set
-    // deliberately when a service gains or loses spec-example coverage.
+fn the_set_of_services_with_spec_example_coverage_is_pinned() {
+    // A tripwire on this file's own fixtures, not a property of the crate: it reads the two
+    // const arrays above, so no production change can make it fail. Its only job is to force a
+    // deliberate edit here when a service gains or loses spec-example coverage. The previous
+    // name claimed it checked coverage of "every service the crate models", which it does not
+    // and cannot -- the crate models 16 request services and 13 have frames below.
     let mut sids: Vec<u8> = REQUESTS.iter().map(|e| e.bytes[0]).collect();
     sids.sort_unstable();
     sids.dedup();
     assert_eq!(
         sids,
         vec![
-            0x14, 0x19, 0x22, 0x28, 0x2E, 0x31, 0x34, 0x36, 0x37, 0x38, 0x3E, 0x85
+            0x14, 0x19, 0x22, 0x27, 0x28, 0x2E, 0x31, 0x34, 0x36, 0x37, 0x38, 0x3E, 0x85
         ],
         "request-side spec-example coverage changed"
     );
 
-    // 0x10, 0x11 and 0x27 appear on the response side only: the standard's request examples
-    // for those services are folded into prose rather than given as byte tables.
+    // Where a modeled service has no request frame here, the reason is that its example
+    // table's byte-value column is not machine-readable in the markdown conversion, NOT that
+    // the standard omits the example. An earlier version of this comment claimed the latter
+    // about 0x10, 0x11 and 0x27, and that was simply wrong: Table 31 (DiagnosticSessionControl),
+    // Table 38 (ECUReset) and Tables 47/49/51 (SecurityAccess) are all request byte tables.
+    //
+    // In Tables 31, 38 and 47 the conversion merged the byte value into the description cell
+    // ("ECUReset Request SID 11 16"), so the values can only be recovered by cross-referencing
+    // the parameter-definition tables — that is inference, not quotation, and quotation is the
+    // whole point of this suite. Table 49 survived the conversion intact and is included above.
+    // Table 472 (RequestUpload) is the same story: bytes #7 and #8 of its memorySize are not
+    // legible, so 0x35 has no frame here despite being fully modeled.
+    //
+    // This is the same class of extraction hazard as the two-bytes-in-one-cell rows noted on
+    // Tables 486 and 487. Verify against the PDF before adding a frame, never against a guess.
     let mut response_sids: Vec<u8> = RESPONSES.iter().map(|e| e.bytes[0]).collect();
     response_sids.sort_unstable();
     response_sids.dedup();


### PR DESCRIPTION
Last of the follow-on branches splitting `api/consistency-pass-1`. **Stacked on #53**, which is
stacked on #51 — review those first; this PR's diff is only its own 23 commits.

With this merged, `api/consistency-pass-1` is fully represented and can be deleted.

This branch is the contested one. It contains the encapsulation and `serde`/`OpenAPI` work **and**
the audit that found much of that work to be wrong, so several commits here undo earlier commits
here. That is deliberate: the alternative was to fold the corrections into what they corrected,
which hides the fact that the first attempt shipped a defect.

## Commit Message Details

### The audit corrections, and what each undoes

Four changes were not merely unnecessary but **wrong**, and are reverted or corrected in
`fix!: undo four changes the churn audit found wrong`:

| change | why it was wrong |
|---|---|
| `LengthFormatIdentifier::reserved_low_nibble` | added on the premise that "ISO leaves that nibble undefined". It does not: Tables 443 and 448 both say bits 3-0 are "reserved by document, to be set to '0'" and give the byte range as `0x00`-`0xF0`. The *old* zeroing behaviour was the conformant one; the change made the crate re-emit a byte the standard forbids |
| invalid ALFID answered NRC `0x13` | Tables 444 and 449 both assign `requestOutOfRange` (`0x31`). Worse, the ALFID commit had deleted the comment recording this while editing those exact lines |
| `Error::IoError` → `generalReject` | Annex A.1: `0x10` "shall only be implemented … if none of the negative response codes defined in this document meet the needs" and "at no means shall this NRC be a general replacement". It appears in no per-service table, so `negative_response_code()` returned a code every `allowed_nack_codes()` rejects. ISO surfaces transport failure as `A_Result = error` (7.4.1.6), so the method now returns `Option` |
| `CommunicationType`'s `serde(try_from = "u8")` | its four unit variants are in bijection with `0x00..=0x03`, so nothing could be smuggled — but `TryFrom<u8>` *masks* the upper bits, so deserializing `17` silently yielded `Normal` and re-serialized as `1`. The fix introduced the exact silent normalisation it set out to eliminate |

Also: `Table 13` was cited for two different things it does not say. The `Cvt` M/C/S/U legend is
**Table 8**; the SPRMIB "both '0' and '1' shall be supported" rule is **Table 11**. Corrected in
three rustdoc sites and the changelog.

### Sealing: 15 attributes added, 10 guarding nothing

`seal only what bears an invariant` splits them by checking each encoder, and the split is not the
one either reviewer proposed:

- **Five struct seals dropped.** `SizePayload`, `FileSizePayload`, `DirSizePayload`,
  `PositionPayload` and `DtcFaultDetectionCounterRecord` have all-`pub` fields and derive their wire
  widths from the values, so no combination can fail. Under the crate's own rule they are data bags.
  The seal cost a downstream the struct literal (`E0639`) and bought nothing — and made
  `DtcFaultDetectionCounterRecord` unbuildable outside the crate entirely.
- **Two kept, with the invariant made real.** `NamePayload` and `SentDataPayload` encoders do
  `u16::try_from(len)` / `u8::try_from(len)` and fail, so an over-long value was constructible and
  only rejected later. `new` now enforces the bound.
- **Three variant seals dropped, because they did not work.** Verified from a downstream crate:
  `serde_json::from_str::<DtcFormatIdentifier>(r#"{"IsoSaeReserved":1}"#)` builds the aliasing state
  the seal claimed to prevent. Sealing blocked the Rust literal and did nothing about `serde`, while
  making both `IsoSaeReserved(b)` and `IsoSaeReserved(..)` `E0603` downstream — so a caller could not
  even read the byte by matching. Replaced with `serde(from = "u8", into = "u8")` plus
  `PartialEq<u8>`, which closes it for all 256 bytes and restores destructuring.
- **One kept with a door added.** `ReadDtcInfoSubFunction::IsoSaeReserved` guards a real invariant
  (bit 7 is SPRMIB, fused at encode) but had no public `TryFrom<u8>`, so sealing it left a tester
  unable to request any unmodeled sub-function. `try_reserved` rejects bit 7.

### `serde`/`OpenAPI`: the mechanism shrank

- **The `TesterPresent` reprs are gone.** 108 lines — two mirror structs, four conversions, four
  schema impls, two `cfg(any(..))` gates, two `allow(dead_code)` — replaced by **three field
  attributes**. The invariant is single-field, and `ZeroSubFunction` already had the `TryFrom<u8>`
  that does the checking. Verified equivalent: serialization is byte-identical, and the schema gained
  `maximum: 127`, which the reprs never advertised despite existing to describe that range.
- **The generated document was invalid.** Four dangling `$ref`s where the derive it replaced had
  zero, because `ToSchema::schemas()` defaults to a no-op and only the derive overrides it. Two
  descriptions were implementation notes — one naming the private `ZeroSubFunction` — and one had
  lost its verb, because utoipa silently drops `#[doc = concat!(..)]`. Every byte schema advertised
  `0..2³¹` while its deserializer rejected above `0x7F`, or `0x0F`.
- **`utoipa` now implies `serde`**, because a `ToSchema` here describes the *serde* representation.
  That removed the last `cfg(any(serde, utoipa))` gates and both `allow(dead_code)`.

### API shape

`new_with_widths(dfi, addr, addr_len, size, size_len)` → `new_with_alfid(dfi, alfid, addr, size)`,
with `AddressAndLengthFormatIdentifier` public under its ISO name and its nibbles private. The two
constructors were independent paths that **disagreed**: the same over-wide address produced
`InvalidMemoryAddress` from one and `IncorrectMessageLengthOrInvalidFormat` from the other — NRC
`0x31` versus `0x13` for one input, untested. `new` now derives its widths and delegates.

Three `pub` fields past a fallible constructor were closed: `WriteDataByIdentifierRequest::data`
let `req.data = &[]` walk around the check and encode a frame the crate's own decoder rejects.

## Issue URL

No linked issue — final split of the `api/consistency-pass-1` work. The **No Issue** label
`pr-lint.yml` offers still does not exist in this repo (noted on #48, #51 and #53).

## Testing

- **281 tests `--all-features`** (251 lib + 18 `public_api` + 3 `openapi_schema` + 3
  `spec_conformance` + 6 doctests) and **258 `--no-default-features`**, all passing on this branch in
  its own right.
- `cargo clippy --all-targets -D warnings -D clippy::pedantic` is **0 across all three configs**.
  This branch completes that cleanup: `main` reports 22 under `--no-default-features`, #53 brought it
  to 17, and this brings it to 0.
- `cargo fmt --all --check`, `cargo doc --no-deps --all-features` and
  `cargo hack check --feature-powerset` (16/16) clean. All four `thumbv6m-none-eabi` combinations
  build.
- **The strongest check on this branch is a tree comparison.** Branch 4's tree was diffed against
  `api/consistency-pass-1`, the fully-verified source branch, and the only differences are the CI
  files from `main`, two markdown table re-alignments from `mdformat`, and the SID conversion tests
  added in #51. Nothing was lost or altered in the split — which matters here, because this branch
  was assembled from a contiguous cherry-pick range plus two commits lifted out of upstream order.
- That comparison caught two real errors: a changelog entry for `RequestTransferExit`'s serde
  derives that I had removed in #53 (where its commit is absent) and had not restored here (where it
  is present), and a stale variant name in the SID test table after this branch renames
  `DynamicallyDefinedDataIdentifier` to ISO's `DynamicallyDefineDataIdentifier`.
- Cherry-picked with `rerere` disabled throughout. Left enabled, it silently auto-staged stale
  resolutions from earlier history rewrites and dropped two non-empty commits while leaving the tree
  and the whole suite green.
